### PR TITLE
Input image URLs with params now work

### DIFF
--- a/app._coffee
+++ b/app._coffee
@@ -89,7 +89,7 @@ app.get '/content/:id', (req, res, _) ->
   res.json 200, content
 
 app.get /^\/https?:\/\/.+/, (req, res, _) ->
-  url = req.url.replace /^\//, ''
+  url = req.url[1..]
   if not url?
     return res.json 400, error:
       message: 'Missing URL'


### PR DESCRIPTION
That capture was getting just the path and not the search string. Using
req.url gets us the whole thing; we just have to shave the slash off
the beginning.

@gasi, if you're happy with this fix, can you merge and deploy?
