### PR TITLE
Enabling service on viewer images from CDN

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -29,7 +29,7 @@ configs = module.exports =
     #
     # Base URL of remote DZI content location
     #
-    REMOTE_URL: "http://content.zoomhub.net/dzis"
+    REMOTE_URL: "content.zoomhub.net"
 
     #
     # What type of data store to use. Options: 'files', 'redis'.

--- a/lib/content._coffee
+++ b/lib/content._coffee
@@ -127,7 +127,7 @@ module.exports = class Content
         raw = @_data.dzi
         return raw if not raw
         clone = {}
-        clone.url = "#{config.REMOTE_URL}/#{@id}.dzi"
+        clone.url = "http://#{config.REMOTE_URL}/dzis/#{@id}.dzi"
         clone[prop] = val for prop, val of raw
         clone
 

--- a/lib/embed._coffee
+++ b/lib/embed._coffee
@@ -11,7 +11,7 @@ SEADRAGON_JS_PATH = Path.join config.STATIC_PATH, 'lib', 'openseadragon', 'opens
 QUEUED_DZI_XML_PATH = Path.join config.STATIC_PATH, 'queued.dzi'
 QUEUED_DZI_XML_URL = config.BASE_URL + config.STATIC_DIR + '/queued.dzi'
 
-VIEWER_IMAGES_URL = config.BASE_URL + config.STATIC_DIR + '/lib/openseadragon/images/'
+VIEWER_IMAGES_URL = 'http://' + config.REMOTE_URL + '/openseadragon-images/'
 
 CLASS_NAME = '__seadragon'
 


### PR DESCRIPTION
This is a short-term change to alleviate load from our servers for the static assets used in the embed. Long term this should be superseded by #80.
