### PR TITLE
Static content db

### DIFF
--- a/lib/content._coffee
+++ b/lib/content._coffee
@@ -12,7 +12,10 @@ DIR_BY_URL_PATH = Path.join config.DATA_DIR, 'content-by-url'
 
 # TODO: this is a short term fix to support the content by url code-path
 # we should remove this when we move to a proper database
-DATABASE = require Path.join DIR_BY_URL_PATH, 'data.json'
+try
+    DATABASE = require Path.join DIR_BY_URL_PATH, 'data.json'
+catch e
+    DATABASE = {}
 
 DIR_PATH_FROM_URL_TO_ID = Path.relative DIR_BY_URL_PATH, DIR_BY_ID_PATH
 
@@ -41,7 +44,10 @@ getFilePathForId = (id) ->
     Path.join DIR_BY_ID_PATH, "#{id}.json"
 
 getFilePathForURL = (url) ->
-    Path.join DIR_BY_ID_PATH, DATABASE["#{hashURL url}.json"].replace "../content-by-id", ""
+    if idFile = DATABASE["#{hashURL url}.json"]
+        Path.join DIR_BY_ID_PATH, idFile.replace '../content-by-id', ''
+    else
+        ''
 
 getRedisKeyForId = (id) ->
     "content:id:#{id}"


### PR DESCRIPTION
This creates a short-term solution to the missing content-by-url files by having a single database with all of the known hashes.

To be superseded by #63 
