### PR TITLE
Restore production: Fix "Version `GLIBC_2.27` not found"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,12 @@ jobs:
         DEPLOY_HOST: staging.zoomhub.net
     <<: *deploy
 
+  deploy-fix-glibc-error:
+    <<: *defaults
+    environment:
+        DEPLOY_HOST: 162.242.218.98
+    <<: *deploy
+
   deploy-production:
     <<: *defaults
     environment:
@@ -119,7 +125,16 @@ workflows:
             - build
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - fix-glibc-error
+      - deploy-fix-glibc-error:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - fix-glibc-error
       - deploy-production:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,6 @@ jobs:
         DEPLOY_HOST: staging.zoomhub.net
     <<: *deploy
 
-  deploy-fix-glibc-error:
-    <<: *defaults
-    environment:
-        DEPLOY_HOST: 162.242.218.98
-    <<: *deploy
-
   deploy-production:
     <<: *defaults
     environment:
@@ -127,13 +121,6 @@ workflows:
             branches:
               ignore:
                 - master
-                - fix-glibc-error
-      - deploy-fix-glibc-error:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
                 - fix-glibc-error
       - deploy-production:
           requires:

--- a/config/keter.yaml
+++ b/config/keter.yaml
@@ -2,7 +2,9 @@ stanzas:
   - type: webapp
     exec: ../zoomhub
     hosts:
-      - 162.242.235.90
+      - 104.239.163.79 # staging
+      - 162.242.235.90 # production 1
+      - 162.242.218.98 # production 2
       - api.zoom.it
       - api.zoomhub.net
       - openzoom.net

--- a/config/keter.yaml
+++ b/config/keter.yaml
@@ -3,8 +3,7 @@ stanzas:
     exec: ../zoomhub
     hosts:
       - 104.239.163.79 # staging
-      - 162.242.235.90 # production 1
-      - 162.242.218.98 # production 2
+      - 162.242.218.98 # production
       - api.zoom.it
       - api.zoomhub.net
       - openzoom.net

--- a/ops/admin.yml
+++ b/ops/admin.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set up admin server
   hosts: admin
-  sudo: yes
+  become: yes
   vars_files:
     - [ 'vars.yml', 'vars.default.yml' ]
     - secrets.vault.yml

--- a/ops/reboot.yml
+++ b/ops/reboot.yml
@@ -1,7 +1,7 @@
 ---
 - name: Reboot server
   hosts: all
-  sudo: yes
+  become: yes
   roles:
     - reboot
 

--- a/ops/roles/keter/tasks/main.yml
+++ b/ops/roles/keter/tasks/main.yml
@@ -46,3 +46,8 @@
   service:
     name: keter
     state: restarted
+
+- name: Ensure `keter` runs on boot
+  systemd:
+    name: keter
+    enabled: yes

--- a/ops/roles/keter/tasks/main.yml
+++ b/ops/roles/keter/tasks/main.yml
@@ -35,10 +35,10 @@
     group=root
     owner=root
 
-- name: Create `/etc/init/keter.conf`
+- name: Create `/lib/systemd/system/keter.service`
   template:
-    src=keter.conf
-    dest=/etc/init/keter.conf
+    src=keter.service
+    dest=/lib/systemd/system/keter.service
     group=root
     owner=root
 

--- a/ops/roles/keter/tasks/main.yml
+++ b/ops/roles/keter/tasks/main.yml
@@ -43,4 +43,6 @@
     owner=root
 
 - name: Restart `keter`
-  service: name=keter state=restarted
+  service:
+    name: keter
+    state: restarted

--- a/ops/roles/keter/tasks/main.yml
+++ b/ops/roles/keter/tasks/main.yml
@@ -12,22 +12,21 @@
 - name: Add `/opt/keter/incoming`
   file: path=/opt/keter/incoming owner={{ admin_user }} state=directory
 
-# # FIXME: Disable until `pyrax is required for this module` error is diagnosed:
-# - name: Download `keter` binary from Rackspace CloudFiles
-#   rax_files_objects:
-#     container={{ rackspace_cloudfiles_admin_container }}
-#     region={{ rackspace_cloudfiles_region }}
-#     method=get
-#     dest=/opt/keter/bin
-#     src="keter-{{ lsb_release.stdout }}"
-#     username={{ rackspace_username }}
-#     api_key={{ rackspace_api_key }}
+- name: Download `keter` binary from Rackspace CloudFiles
+  rax_files_objects:
+    container={{ rackspace_cloudfiles_admin_container }}
+    region={{ rackspace_cloudfiles_region }}
+    method=get
+    dest=/opt/keter/bin
+    src="keter-{{ lsb_release.stdout }}"
+    username={{ rackspace_username }}
+    api_key={{ rackspace_api_key }}
 
-# - name: Drop `keter` release suffix
-#   command: mv /opt/keter/bin/keter-{{ lsb_release.stdout }} /opt/keter/bin/keter
+- name: Drop `keter` release suffix
+  command: mv /opt/keter/bin/keter-{{ lsb_release.stdout }} /opt/keter/bin/keter
 
-# - name: Make `/opt/keter/bin/keter` executable
-#   file: path=/opt/keter/bin/keter mode=0755
+- name: Make `/opt/keter/bin/keter` executable
+  file: path=/opt/keter/bin/keter mode=0755
 
 - name: Create `/opt/keter/etc/keter-config.yaml`
   template:

--- a/ops/roles/keter/templates/keter.conf
+++ b/ops/roles/keter/templates/keter.conf
@@ -1,8 +1,0 @@
-# /etc/init/keter.conf
-start on (net-device-up and local-filesystems and runlevel [2345])
-stop on runlevel [016]
-respawn
-
-console none
-
-exec /opt/keter/bin/keter /opt/keter/etc/keter-config.yaml

--- a/ops/roles/keter/templates/keter.service
+++ b/ops/roles/keter/templates/keter.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Keter - Web application deployment manager
+
+[Service]
+ExecStart=/opt/keter/bin/keter /opt/keter/etc/keter-config.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/roles/reboot/tasks/main.yml
+++ b/ops/roles/reboot/tasks/main.yml
@@ -7,7 +7,7 @@
   when: reboot == "yes"
 
 - name: waiting for server to come back
-  sudo: False
+  become: no
   local_action: wait_for host="{{ inventory_hostname }}"
                 port=22 delay=1 timeout=300
   when: reboot == "yes"

--- a/ops/web.yml
+++ b/ops/web.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set up web server
   hosts: web
-  sudo: yes
+  become: yes
   vars_files:
     - [ 'vars.yml', 'vars.default.yml' ]
     - secrets.vault.yml

--- a/zh
+++ b/zh
@@ -53,7 +53,7 @@ ops)
     ;;
     setup-admin-server)
         ansible-playbook -v --inventory-file ops/admin \
-            --ask-sudo --ask-vault-pass \
+            --ask-become --ask-vault-pass \
             ops/admin.yml
         ;;
     setup-database-server)
@@ -68,7 +68,7 @@ ops)
 
         echo 'Enter `admin` user password:'
         ansible-playbook -v --inventory-file "$hosts" \
-            --ask-sudo --ask-vault-pass \
+            --ask-become --ask-vault-pass \
             ops/web.yml
         ;;
     *)


### PR DESCRIPTION
Our Ubuntu 14 (Trusty) production server from 2016 couldn’t run the latest binary built on CircleCI. This change upgrades our web server from Ubuntu 14 (Trusty) to Ubuntu 18 (Bionic) hopefully slows down the bit rot for a while.

### Changes

- [x] Upgrade from Ansible 1.9 to 2.x
- [x] Restore download of `keter` binary
- [x] Migrate from `/etc/init.d` to `systemd`