### PR TITLE
Restore `/version` endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ deploy: &deploy
           echo 'export ZH_AWS_EB_PROJECT="$ZH_AWS_EB_PROJECT"' >> $BASH_ENV
           echo 'export ZH_AWS_ECR_REPO="$ZH_AWS_ECR_REPO"' >> $BASH_ENV
 
+    - run: echo $CIRCLE_SHA1 > ~/zoomhub/zoomhub/workspace/version.txt
+
     - aws-cli/setup
 
     # Set up Docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ZoomHub
 
+## 3.0.0-alpha.2 – June 28, 2020
+
+- Restore `/version` endpoint.
+
 ## 3.0.0-alpha.1 – June 28, 2020
 
 - Migrate hosting from Rackspace to Amazon AWS:

--- a/ops/aws/Dockerfile.deploy
+++ b/ops/aws/Dockerfile.deploy
@@ -12,6 +12,7 @@ RUN apt-get upgrade -y && \
 
 ADD .ebextensions/ /opt/zoomhub/.ebextensions
 ADD run.sh /opt/zoomhub
+ADD version.txt /opt/zoomhub
 ADD public /opt/zoomhub/public
 ADD zoomhub /opt/zoomhub
 

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -1,5 +1,5 @@
 name:                zoomhub
-version:             2.0.0.0
+version:             3.0.0.2
 synopsis:            Share and view high-resolution images effortlessly.
 description:         Please see README.md
 homepage:            http://github.com/zoomhub/zoomhub#readme
@@ -7,7 +7,7 @@ license:             MIT
 license-file:        LICENSE
 author:              ZoomHub
 maintainer:          zoomhub@googlegroups.com
-copyright:           2013–2016 ZoomHub
+copyright:           2013–2020 ZoomHub
 category:            Web
 build-type:          Simple
 -- extra-source-files:


### PR DESCRIPTION
We were missing the `version.txt` file that we needed to create during the build / Docker packaging phase.