### PR TITLE
Stop deploying WIP to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
   deploy-staging:
     <<: *defaults
     environment:
-      ZH_AWS_EB_ENVIRONMENT: production # TODO: Create `staging` environment
+      ZH_AWS_EB_ENVIRONMENT: staging # TODO: Create `staging` environment
     <<: *deploy
 
   deploy-production:
@@ -177,13 +177,14 @@ workflows:
   build-deploy:
     jobs:
       - build-and-test
-      - deploy-staging:
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              ignore:
-                - master
+      # TODO: Re-enable staging deploys once we have an environment
+      # - deploy-staging:
+      #     requires:
+      #       - build-and-test
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
       - deploy-production:
           requires:
             - build-and-test

--- a/ops/CHANGELOG.md
+++ b/ops/CHANGELOG.md
@@ -1,0 +1,5 @@
+# ZoomHub operations
+
+## 2020-07-15-1
+
+- Stop deploying PR changes to production.


### PR DESCRIPTION
Determine costs of running separate staging environment and enable it for WIP branches if possible.