### PR TITLE
CircleCI: Fix configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
               stack build --test \
                           --no-run-tests \
                           --no-terminal \
-                          --jobs 4 \
+                          --jobs 2 \
                           --install-ghc \
                           --pedantic \
                           --ghc-options='-O2' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ jobs:
               stack build --test \
                           --no-run-tests \
                           --no-terminal \
+                          --jobs 4 \
                           --install-ghc \
                           --pedantic \
                           --ghc-options='-O2' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,7 @@ workflows:
       #           - master
       - deploy-production:
           requires:
+            - process-content-build
             - web-build-and-test
           filters:
             branches:

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -23,7 +23,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Time as Time
-import qualified Debug.Trace as Trace
 import GHC.Generics (Generic)
 import Network.Minio as Minio
   ( awsCI,
@@ -396,7 +395,7 @@ restContentCompletionById ::
   ContentCompletion ->
   Handler Content
 restContentCompletionById baseURI contentBaseURI dbConnPool authResult contentId completion = do
-  case Trace.trace "authResult" authResult of
+  case authResult of
     Authenticated _ -> do
       maybeContent <- liftIO $ flip runPoolPQ dbConnPool $ case completion of
         Completion.Success sc ->


### PR DESCRIPTION
Our `deploy-production` job didn’t wait for `process-content-build` to finish, so we were missing the required deploy script.