### PR TITLE
CI: Update binaries cache

### DIFF
--- a/.github/workflows/zoomhub.yml
+++ b/.github/workflows/zoomhub.yml
@@ -64,14 +64,14 @@ jobs:
         id: cache-stack-binaries
         uses: actions/cache@v2
         env:
-          cache-name: cache-stack-binaries-v3
+          cache-name: cache-stack-binaries-v4
         with:
           path: |
             bin/zoomhub
             bin/migrate-database
-          key: web-build-v1-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/stack.yaml') }}-${{ hashFiles('**/stack.yaml.lock') }}-${{ hashFiles('**/package.yaml') }}-${{ hashFiles('data/*') }}
+          key: web-build-v1-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/stack.yaml') }}-${{ hashFiles('**/stack.yaml.lock') }}-${{ hashFiles('**/package.yaml') }}-${{ hashFiles('data/*') }}-${{ hashFiles('**/*.hs') }}
           restore-keys: |
-            web-build-v1-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/stack.yaml') }}-${{ hashFiles('**/stack.yaml.lock') }}-${{ hashFiles('**/package.yaml') }}-${{ hashFiles('data/*') }}
+            web-build-v1-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/stack.yaml') }}-${{ hashFiles('**/stack.yaml.lock') }}-${{ hashFiles('**/package.yaml') }}-${{ hashFiles('data/*') }}-${{ hashFiles('**/*.hs') }}
 
       - name: Build
         if: steps.cache-stack-binaries.outputs.cache-hit != 'true'


### PR DESCRIPTION
Only cache binaries if source files have not changed. This is helpful if one is
iterating on CI and wants to avoid rebuilding the Haskell source and binaries.

Noticed the existing cache was too aggressive when I reformatted the code and
the build was skipped because `.cabal`, `stack.yaml`, etc. files didn’t
change.