### PR TITLE
Send email verification link

### DIFF
--- a/API.md
+++ b/API.md
@@ -81,6 +81,12 @@ Note that all response objects have a `content`, `dzi`, or `error` object.
 - 400 w/ error message if URL is invalid (e.g. malformed)
 - 503 w/ error message if URL is new and ZoomHub is closed for new content
 
+`PUT /v1/content/:id/verification/:token`
+
+- 3xx to `/v1/content/:id`, w/ `Content` object for convenience, if ID and token are valid
+- 401 w/ error message if verification token is invalid (e.g. malformed)
+- 404 if content is not found
+
 `GET /v1/dzi/:id` (**_TODO_**)
 
 - 3xx to DZI URL, w/ DZI object for convenience, if exists and ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # ZoomHub
 
-## Unreleased
+## 2021-09-24
 
+- Send submitter an email with a verification link to authenticate the upload.
+  After verification, our background worker picks up unprocessed submissions and
+  processes them via AWS Lambda.
+- Introduce `ZH_ENV = "development" | "test" | "production"` environment
+  variable for controlling certain actions, e.g. not sending emails during
+  testing.
+- Set content version to `5` on new submissions. These are submissions that
+  have a submitter email and verification token.
+- Control logging via `LOG_LEVEL` environment variable. Extract `LogLevel`
+  module and introduce `logLevel` configuration for controlling what level of
+  logs we want to capture.
+- Pipe AWS logs through our own JSON logger.
+- Reduce log level of many worker operations to reduce noise.
 - Remove unused `S3_CACHE_BUCKET` from Haskell web server.
 
 ## 2021-09-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ZoomHub
 
+## Unreleased
+
+- Remove unused `S3_CACHE_BUCKET` from Haskell web server.
+
 ## 2021-09-09
 
 - Generate verification token for each new submission. This will be used to

--- a/public/index.html
+++ b/public/index.html
@@ -438,8 +438,9 @@
     <script>
       async function upload(file) {
         // TODO: Handle errors
-        const email = document.querySelector('.upload-form input[name="email"]')
-          .value
+        const email = document.querySelector(
+          '.upload-form input[name="email"]'
+        ).value
         // TODO: Handle errors
         const presignedPostData = await fetch(
           "/v1/content/upload?email=" + email

--- a/scripts/run-development.sh
+++ b/scripts/run-development.sh
@@ -25,9 +25,8 @@ PGDATABASE='zoomhub_development' \
 PGUSER="$(whoami)" \
 PROCESS_CONTENT='ProcessExistingAndNewContent' \
 PROCESSING_WORKERS='2' \
-S3_CACHE_BUCKET='cache-development.zoomhub.net' \
 S3_SOURCES_BUCKET='sources-development.zoomhub.net' \
 UPLOADS='true' \
-  stack exec zoomhub | jq &
+  stack exec zoomhub &
 
 echo $! > zoomhub.pid

--- a/scripts/run-development.sh
+++ b/scripts/run-development.sh
@@ -27,6 +27,6 @@ PROCESS_CONTENT='ProcessExistingAndNewContent' \
 PROCESSING_WORKERS='2' \
 S3_SOURCES_BUCKET='sources-development.zoomhub.net' \
 UPLOADS='true' \
-  stack exec zoomhub &
+  stack exec zoomhub | jq &
 
 echo $! > zoomhub.pid

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -547,12 +547,13 @@ restContentByURL config baseURI dbConnPool processContent url mEmail = do
     (Just content, _) ->
       redirectToAPI baseURI (Internal.contentId content)
   where
+    logLevel = Config.logLevel config
     awsConfig = Config.aws config
     environment = Config.environment config
     sendEmail contentId submitterEmail verificationToken =
       void $
         liftIO $
-          Email.send awsConfig $
+          Email.send awsConfig logLevel $
             Verification.request
               baseURI
               contentId

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -551,15 +551,14 @@ restContentByURL config baseURI dbConnPool processContent url mEmail = do
     awsConfig = Config.aws config
     environment = Config.environment config
     sendEmail contentId submitterEmail verificationToken =
-      void $
-        liftIO $
-          Email.send awsConfig logLevel $
-            Verification.request
-              baseURI
-              contentId
-              verificationToken
-              (Email.From "\"ZoomHub\" <daniel@zoomhub.net>")
-              (Email.To submitterEmail)
+      void . liftIO $
+        Email.send awsConfig logLevel $
+          Verification.request
+            baseURI
+            contentId
+            verificationToken
+            (Email.From "\"ZoomHub\" <daniel@zoomhub.net>")
+            (Email.To submitterEmail)
 
 restInvalidRequest :: Maybe String -> Handler Content
 restInvalidRequest maybeURL = case maybeURL of

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -421,7 +421,7 @@ restUpload baseURI awsConfig uploads email =
                   return $ lenientDecodeUtf8 <$> HS.insert "url" (encodeUtf8 s3BucketURL) formData
       where
         minUploadSizeBytes = 1
-        maxUploadSizeBytes = 512 * 1024 * 1024
+        maxUploadSizeBytes = 512 * 1024 * 1024 -- 512MB
         s3Bucket = AWS.configSourcesS3Bucket awsConfig
 
 restUploadWithoutEmail :: Uploads -> Handler (HashMap Text Text)

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -393,7 +393,7 @@ restUpload baseURI awsConfig uploads email =
                 PPCEquals
                   "success_action_redirect"
                   -- TODO: Use type-safe links
-                  ( fold $
+                  ( fold
                       [ T.pack $ show baseURI,
                         "/v1/content",
                         "?email=",
@@ -417,7 +417,7 @@ restUpload baseURI awsConfig uploads email =
               case result of
                 Left minioErr ->
                   return $ HS.singleton "error" (T.pack $ show minioErr)
-                Right (_url, formData) -> do
+                Right (_url, formData) ->
                   return $ lenientDecodeUtf8 <$> HS.insert "url" (encodeUtf8 s3BucketURL) formData
       where
         minUploadSizeBytes = 1
@@ -449,7 +449,7 @@ restContentInvalidVerificationToken ::
   ContentId ->
   String -> -- VerificationToken
   Handler Content
-restContentInvalidVerificationToken _contentId verificationToken = do
+restContentInvalidVerificationToken _contentId verificationToken =
   throwError . API.error401 $ "Invalid verification token: " <> verificationToken
 
 restContentCompletionById ::
@@ -460,7 +460,7 @@ restContentCompletionById ::
   ContentId ->
   ContentCompletion ->
   Handler Content
-restContentCompletionById baseURI contentBaseURI dbConnPool authResult contentId completion = do
+restContentCompletionById baseURI contentBaseURI dbConnPool authResult contentId completion =
   case authResult of
     Authenticated _ -> do
       maybeContent <- liftIO $
@@ -511,7 +511,7 @@ restContentByURL ::
 restContentByURL baseURI dbConnPool processContent url mEmail = do
   maybeContent <- liftIO $ runPoolPQ (PG.getByURL' url) dbConnPool
   case (maybeContent, mEmail) of
-    (Nothing, Nothing) -> do
+    (Nothing, Nothing) ->
       missingEmailErrorAPI
     (Nothing, Just email) -> do
       mNewContent <- case processContent of

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -176,6 +176,7 @@ type API =
       :> "upload"
       :> RequiredQueryParam "email" Text -- TODO: Introduce `Email` type
       :> Get '[JSON] (HashMap Text Text)
+    -- API: Error: RESTful: Upload without email
     :<|> "v1"
       :> "content"
       :> "upload"

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -537,6 +537,7 @@ restContentByURL awsConfig baseURI dbConnPool processContent url mEmail = do
                         (Email.To submitterEmail)
               _ ->
                 pure ()
+          -- TODO: Redirect to content:
           pure maybeNewContent
         _ ->
           noNewContentErrorAPI

--- a/src/ZoomHub/AWS.hs
+++ b/src/ZoomHub/AWS.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module ZoomHub.AWS
+  ( run,
+  )
+where
+
+import Control.Lens ((&), (.~))
+import Control.Monad.Catch (MonadCatch)
+import Data.Text.Encoding (encodeUtf8)
+import Network.AWS (AccessKey (AccessKey), Credentials (FromKeys), SecretKey (SecretKey))
+import qualified Network.AWS as AWS
+import System.IO (stdout)
+import UnliftIO (MonadUnliftIO)
+import qualified ZoomHub.Config.AWS as Config
+
+run :: (MonadCatch m, MonadUnliftIO m) => Config.Config -> AWS.AWS a -> m a
+run config action = do
+  logger <- AWS.newLogger AWS.Debug stdout
+  env <-
+    AWS.newEnv $
+      FromKeys
+        (AccessKey . encodeUtf8 . Config.configAccessKeyId $ config)
+        (SecretKey . encodeUtf8 . Config.configSecretAccessKey $ config)
+  AWS.runResourceT
+    . AWS.runAWS (env & AWS.envLogger .~ logger)
+    . AWS.within (Config.configRegion config)
+    $ action

--- a/src/ZoomHub/AWS.hs
+++ b/src/ZoomHub/AWS.hs
@@ -6,23 +6,43 @@ module ZoomHub.AWS
 where
 
 import Control.Lens ((&), (.~))
+import Control.Monad (when)
 import Control.Monad.Catch (MonadCatch)
+import Data.Binary.Builder (Builder)
+import qualified Data.Binary.Builder as Builder
+import qualified Data.ByteString.Lazy.UTF8 as BL
 import Data.Text.Encoding (encodeUtf8)
 import Network.AWS (AccessKey (AccessKey), Credentials (FromKeys), SecretKey (SecretKey))
 import qualified Network.AWS as AWS
-import System.IO (stdout)
 import UnliftIO (MonadUnliftIO)
 import qualified ZoomHub.Config.AWS as Config
+import qualified ZoomHub.Log.Logger as Logger
 
-run :: (MonadCatch m, MonadUnliftIO m) => Config.Config -> AWS.AWS a -> m a
-run config action = do
-  logger <- AWS.newLogger AWS.Debug stdout
+run ::
+  (MonadCatch m, MonadUnliftIO m) =>
+  Config.Config ->
+  Logger.LogLevel ->
+  AWS.AWS a ->
+  m a
+run config logLevel action = do
   env <-
     AWS.newEnv $
       FromKeys
         (AccessKey . encodeUtf8 . Config.configAccessKeyId $ config)
         (SecretKey . encodeUtf8 . Config.configSecretAccessKey $ config)
   AWS.runResourceT
-    . AWS.runAWS (env & AWS.envLogger .~ logger)
+    . AWS.runAWS (env & AWS.envLogger .~ logger logLevel)
     . AWS.within (Config.configRegion config)
     $ action
+
+logger :: Logger.LogLevel -> AWS.LogLevel -> Builder -> IO ()
+logger minimumLogLevel logLevel builder =
+  when (actualLogLevel >= minimumLogLevel) $
+    Logger.log_ actualLogLevel (BL.toString . Builder.toLazyByteString $ builder)
+  where
+    actualLogLevel = level logLevel
+
+    level AWS.Info = Logger.Info
+    level AWS.Error = Logger.Error
+    level AWS.Debug = Logger.Debug
+    level AWS.Trace = Logger.Debug

--- a/src/ZoomHub/Config.hs
+++ b/src/ZoomHub/Config.hs
@@ -20,6 +20,7 @@ import Squeal.PostgreSQL.Pool (Pool)
 import qualified ZoomHub.Config.AWS as AWS
 import ZoomHub.Config.ProcessContent (ProcessContent (..))
 import ZoomHub.Config.Uploads (Uploads (..))
+import ZoomHub.Log.LogLevel (LogLevel)
 import ZoomHub.Storage.PostgreSQL (Connection)
 import ZoomHub.Types.APIUser (APIUser)
 import ZoomHub.Types.BaseURI (BaseURI)
@@ -44,6 +45,7 @@ data Config = Config
     environment :: Environment,
     error404 :: BL.ByteString,
     logger :: Middleware,
+    logLevel :: LogLevel,
     openSeadragonScript :: String,
     port :: Integer,
     processContent :: ProcessContent,
@@ -63,6 +65,7 @@ instance ToJSON Config where
         "dbConnPoolIdleTime" .= dbConnPoolIdleTime,
         "dbConnPoolMaxResourcesPerStripe" .= dbConnPoolMaxResourcesPerStripe,
         "dbConnPoolNumStripes" .= dbConnPoolNumStripes,
+        "logLevel" .= show logLevel,
         "port" .= port,
         "processContent" .= processContent,
         "publicPath" .= publicPath,

--- a/src/ZoomHub/Config/AWS.hs
+++ b/src/ZoomHub/Config/AWS.hs
@@ -8,17 +8,19 @@ where
 
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Network.AWS as AWS
 import System.Environment (getEnvironment)
 
 data Config = Config
   { configAccessKeyId :: Text,
     configSecretAccessKey :: Text,
     configContentS3Bucket :: Text,
-    configSourcesS3Bucket :: Text
+    configSourcesS3Bucket :: Text,
+    configRegion :: AWS.Region
   }
 
-fromEnv :: IO (Maybe Config)
-fromEnv = do
+fromEnv :: AWS.Region -> IO (Maybe Config)
+fromEnv region = do
   env <- getEnvironment
   -- TODO: Refactor to use named instead of positional arguments:
   return $
@@ -27,3 +29,4 @@ fromEnv = do
       <*> (T.pack <$> lookup "AWS_SECRET_ACCESS_KEY" env)
       <*> (T.pack <$> lookup "S3_CACHE_BUCKET" env)
       <*> (T.pack <$> lookup "S3_SOURCES_BUCKET" env)
+      <*> Just region

--- a/src/ZoomHub/Config/AWS.hs
+++ b/src/ZoomHub/Config/AWS.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module ZoomHub.Config.AWS
   ( Config (..),
     fromEnv,
+    isTest,
+    dangerouslyToString,
   )
 where
 
@@ -28,3 +31,27 @@ fromEnv region = do
       <*> (T.pack <$> lookup "AWS_SECRET_ACCESS_KEY" env)
       <*> (T.pack <$> lookup "S3_SOURCES_BUCKET" env)
       <*> Just region
+
+-- HACK: Avoid network calls in test environment.
+-- TODO: Replace with handle pattern or typeclasses.
+isTest :: Config -> Bool
+isTest Config {..} =
+  configAccessKeyId == "<TEST>"
+    && configSecretAccessKey == "<TEST>"
+    && configSourcesS3Bucket == "<TEST>"
+
+dangerouslyToString :: Config -> String
+dangerouslyToString Config {..} =
+  "Config { "
+    <> "configAccessKeyId = "
+    <> show configAccessKeyId
+    <> ", "
+    <> "configSecretAccessKey = "
+    <> show configSecretAccessKey
+    <> ", "
+    <> "configSourcesS3Bucket = "
+    <> show configSourcesS3Bucket
+    <> ", "
+    <> "configRegion = "
+    <> show configRegion
+    <> " }"

--- a/src/ZoomHub/Config/AWS.hs
+++ b/src/ZoomHub/Config/AWS.hs
@@ -14,7 +14,6 @@ import System.Environment (getEnvironment)
 data Config = Config
   { configAccessKeyId :: Text,
     configSecretAccessKey :: Text,
-    configContentS3Bucket :: Text,
     configSourcesS3Bucket :: Text,
     configRegion :: AWS.Region
   }
@@ -27,6 +26,5 @@ fromEnv region = do
     Config
       <$> (T.pack <$> lookup "AWS_ACCESS_KEY_ID" env)
       <*> (T.pack <$> lookup "AWS_SECRET_ACCESS_KEY" env)
-      <*> (T.pack <$> lookup "S3_CACHE_BUCKET" env)
       <*> (T.pack <$> lookup "S3_SOURCES_BUCKET" env)
       <*> Just region

--- a/src/ZoomHub/Config/AWS.hs
+++ b/src/ZoomHub/Config/AWS.hs
@@ -4,8 +4,6 @@
 module ZoomHub.Config.AWS
   ( Config (..),
     fromEnv,
-    isTest,
-    dangerouslyToString,
   )
 where
 
@@ -31,27 +29,3 @@ fromEnv region = do
       <*> (T.pack <$> lookup "AWS_SECRET_ACCESS_KEY" env)
       <*> (T.pack <$> lookup "S3_SOURCES_BUCKET" env)
       <*> Just region
-
--- HACK: Avoid network calls in test environment.
--- TODO: Replace with handle pattern or typeclasses.
-isTest :: Config -> Bool
-isTest Config {..} =
-  configAccessKeyId == "<TEST>"
-    && configSecretAccessKey == "<TEST>"
-    && configSourcesS3Bucket == "<TEST>"
-
-dangerouslyToString :: Config -> String
-dangerouslyToString Config {..} =
-  "Config { "
-    <> "configAccessKeyId = "
-    <> show configAccessKeyId
-    <> ", "
-    <> "configSecretAccessKey = "
-    <> show configSecretAccessKey
-    <> ", "
-    <> "configSourcesS3Bucket = "
-    <> show configSourcesS3Bucket
-    <> ", "
-    <> "configRegion = "
-    <> show configRegion
-    <> " }"

--- a/src/ZoomHub/Email.hs
+++ b/src/ZoomHub/Email.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module ZoomHub.Email
+  ( Email (..),
+    From (..),
+    To (..),
+    send,
+  )
+where
+
+import Control.Lens ((&), (.~), (?~))
+import Data.Text (Text)
+import qualified Network.AWS as AWS
+import qualified Network.AWS.SES as SES
+import qualified ZoomHub.AWS as ZHAWS
+import qualified ZoomHub.Config.AWS as AWS
+
+data Email = Email
+  { from :: From,
+    to :: To,
+    subject :: Text,
+    body :: Text
+  }
+
+newtype From = From {unFrom :: Text}
+
+newtype To = To {unTo :: Text}
+
+send :: AWS.Config -> Email -> IO SES.SendEmailResponse
+send config Email {..} =
+  ZHAWS.run config $
+    AWS.send $
+      SES.sendEmail (unFrom from) destination message
+  where
+    destination = SES.destination & SES.dToAddresses .~ [unTo to]
+
+    message = SES.message content' body'
+    content' = SES.content "" & SES.cData .~ subject
+    body' = SES.body & SES.bText ?~ SES.content body

--- a/src/ZoomHub/Email.hs
+++ b/src/ZoomHub/Email.hs
@@ -15,6 +15,7 @@ import qualified Network.AWS as AWS
 import qualified Network.AWS.SES as SES
 import qualified ZoomHub.AWS as ZHAWS
 import qualified ZoomHub.Config.AWS as AWS
+import ZoomHub.Log.Logger (LogLevel)
 
 data Email = Email
   { from :: From,
@@ -27,9 +28,9 @@ newtype From = From {unFrom :: Text}
 
 newtype To = To {unTo :: Text}
 
-send :: AWS.Config -> Email -> IO SES.SendEmailResponse
-send config Email {..} =
-  ZHAWS.run config $
+send :: AWS.Config -> LogLevel -> Email -> IO SES.SendEmailResponse
+send config logLevel Email {..} =
+  ZHAWS.run config logLevel $
     AWS.send $
       SES.sendEmail (unFrom from) destination message
   where

--- a/src/ZoomHub/Email/Verification.hs
+++ b/src/ZoomHub/Email/Verification.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module ZoomHub.Email.Verification
+  ( request,
+  )
+where
+
+import qualified Data.Text as T
+import ZoomHub.Email (Email (..), From, To)
+import ZoomHub.Types.BaseURI (BaseURI)
+import ZoomHub.Types.ContentId (ContentId, unContentId)
+import ZoomHub.Types.VerificationToken (VerificationToken)
+
+-- TODO: Distinguish between upload and URL submission:
+request :: BaseURI -> ContentId -> VerificationToken -> From -> To -> Email
+request baseURI contentId verificationToken from to =
+  Email {from, to, subject, body}
+  where
+    subject = "ZoomHub: View your submission"
+    body =
+      "Hi,\n\
+      \\n\
+      \Thanks for your submission to ZoomHub (formerly zoom.it).\n\
+      \\n\
+      \To view it, please follow this link:\n"
+        <> verificationURL
+        <> "\n\nIf you haven’t submitted anything to ZoomHub, just ignore this email.\n\n\
+           \Thanks,\n\
+           \Daniel from ZoomHub\n"
+    verificationURL =
+      T.pack (show baseURI)
+        <> "/v1/content/"
+        <> T.pack (unContentId contentId)
+        <> "/verification/"
+        <> T.pack (show verificationToken)

--- a/src/ZoomHub/Email/Verification.hs
+++ b/src/ZoomHub/Email/Verification.hs
@@ -27,7 +27,8 @@ request baseURI contentId verificationToken from to =
         <> verificationURL
         <> "\n\nIf you haven’t submitted anything to ZoomHub, just ignore this email.\n\n\
            \Thanks,\n\
-           \Daniel from ZoomHub\n"
+           \Daniel from ZoomHub\n\n\
+           \P.S. If you have questions or feedback, simply reply to this email. I read each and every one."
     verificationURL =
       T.pack (show baseURI)
         <> "/v1/content/"

--- a/src/ZoomHub/Email/Verification.hs
+++ b/src/ZoomHub/Email/Verification.hs
@@ -21,14 +21,14 @@ request baseURI contentId verificationToken from to =
     body =
       "Hi,\n\
       \\n\
-      \Thanks for your submission to ZoomHub (formerly zoom.it).\n\
+      \Thank you for your submission to ZoomHub (formerly zoom.it).\n\
       \\n\
-      \To view it, please follow this link:\n"
+      \To view it, please follow this link: "
         <> verificationURL
-        <> "\n\nIf you haven’t submitted anything to ZoomHub, just ignore this email.\n\n\
+        <> "\n\nIf you haven’t submitted anything to ZoomHub, please ignore this email.\n\n\
            \Thanks,\n\
-           \Daniel from ZoomHub\n\n\
-           \P.S. If you have questions or feedback, simply reply to this email. I read each and every one."
+           \Daniel from ZoomHub\n\n\n\
+           \P.S. If you have any questions or feedback, simply reply to this email. I read each and every message."
     verificationURL =
       T.pack (show baseURI)
         <> "/v1/content/"

--- a/src/ZoomHub/Log/LogLevel.hs
+++ b/src/ZoomHub/Log/LogLevel.hs
@@ -1,0 +1,25 @@
+module ZoomHub.Log.LogLevel
+  ( LogLevel (..),
+    parse,
+  )
+where
+
+data LogLevel
+  = Debug
+  | Info
+  | Warning
+  | Error
+  deriving (Eq, Ord)
+
+instance Show LogLevel where
+  show Debug = "debug"
+  show Info = "info"
+  show Warning = "warning"
+  show Error = "error"
+
+parse :: String -> Maybe LogLevel
+parse "debug" = Just Debug
+parse "info" = Just Info
+parse "warning" = Just Warning
+parse "error" = Just Error
+parse _ = Nothing

--- a/src/ZoomHub/Log/Logger.hs
+++ b/src/ZoomHub/Log/Logger.hs
@@ -13,6 +13,10 @@ module ZoomHub.Log.Logger
     logInfo_,
     logWarning,
     logWarning_,
+    log,
+    log_,
+    -- LogLevel
+    LogLevel (..),
     -- Encoding
     encodeLogLine,
   )
@@ -41,16 +45,9 @@ import Data.Time.Units (Millisecond)
 import Data.Time.Units.Instances ()
 import System.IO (hSetEncoding, stderr, stdout, utf8)
 import System.TimeIt (timeItT)
+import ZoomHub.Log.LogLevel (LogLevel (..))
 import ZoomHub.Utils (lenientDecodeUtf8)
 import Prelude hiding (log)
-
-data Level = Debug | Info | Warning | Error deriving (Eq)
-
-instance Show Level where
-  show Debug = "debug"
-  show Info = "info"
-  show Warning = "warning"
-  show Error = "error"
 
 logDebug :: String -> [Pair] -> IO ()
 logDebug = log Debug
@@ -88,10 +85,10 @@ logException msg e meta = logError msg (meta ++ ["error" .= show e])
 logException_ :: String -> SomeException -> IO ()
 logException_ msg e = logException msg e []
 
-log_ :: Level -> String -> IO ()
+log_ :: LogLevel -> String -> IO ()
 log_ level message = log level message []
 
-logT :: Level -> String -> [Pair] -> IO a -> IO a
+logT :: LogLevel -> String -> [Pair] -> IO a -> IO a
 logT level msg meta action = do
   (duration, result) <- timeItT action
   log
@@ -100,7 +97,7 @@ logT level msg meta action = do
     (meta ++ ["duration" .= (round (duration * 1000) :: Millisecond)])
   return result
 
-log :: Level -> String -> [Pair] -> IO ()
+log :: LogLevel -> String -> [Pair] -> IO ()
 log level message meta = do
   now <- getCurrentTime
   -- Force to UTF8 to avoid the dreaded `<stdout>: commitAndReleaseBuffer:

--- a/src/ZoomHub/Storage/PostgreSQL.hs
+++ b/src/ZoomHub/Storage/PostgreSQL.hs
@@ -123,7 +123,6 @@ getNextUnprocessed = do
                         )
                 )
               & orderBy [#content ! #initialized_at & Asc]
-              & orderBy [#content ! #version & Desc]
               & orderBy [#content ! #num_views & Desc]
               & limit 1
       )

--- a/src/ZoomHub/Storage/PostgreSQL/Internal.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Internal.hs
@@ -387,7 +387,7 @@ insertContent =
             :* Default `as` #abuse_level_id
             :* Default `as` #num_abuse_reports
             :* Default `as` #num_views
-            :* Default `as` #version
+            :* Set (literal Content.version) `as` #version
             :* Set (param @2) `as` #submitter_email
             :* Set (param @3) `as` #verification_token
             :* Default `as` #verified_at
@@ -754,7 +754,7 @@ contentToRow c =
       crAbuseLevelId = 0, -- TODO: Replace hard-coded value
       crNumAbuseReports = 0,
       crNumViews = contentNumViews c,
-      crVersion = fromIntegral Content.version,
+      crVersion = Content.version,
       crSubmitterEmail = contentSubmitterEmail c,
       crVerificationToken = contentVerificationToken c,
       crVerifiedAt = contentVerifiedAt c

--- a/src/ZoomHub/Storage/PostgreSQL/Schema/Schema3.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Schema/Schema3.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -O0 #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}

--- a/src/ZoomHub/Types/Content.hs
+++ b/src/ZoomHub/Types/Content.hs
@@ -20,6 +20,7 @@ module ZoomHub.Types.Content
   )
 where
 
+import Data.Int (Int32)
 import ZoomHub.Types.Content.Internal
   ( Content,
     contentActiveAt,
@@ -52,5 +53,5 @@ import ZoomHub.Types.Content.Internal
 --   - `verification_token`
 --   - `verified_at`
 --   for tracking the author of a submission or upload.
-version :: Int
+version :: Int32
 version = 5

--- a/src/ZoomHub/Types/VerificationToken.hs
+++ b/src/ZoomHub/Types/VerificationToken.hs
@@ -11,10 +11,12 @@ module ZoomHub.Types.VerificationToken
     VerificationToken' (VerificationToken),
     -- TODO: Can we test this without exporting it?
     unVerificationToken,
+    fromText,
   )
 where
 
 import Data.Maybe (fromJust)
+import Data.Text (Text)
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Servant (FromHttpApiData, parseUrlPiece)
@@ -27,6 +29,9 @@ type VerificationToken = VerificationToken' UUID
 
 instance Show VerificationToken where
   show = UUID.toString . unVerificationToken
+
+fromText :: Text -> Maybe VerificationToken
+fromText t = VerificationToken <$> UUID.fromText t
 
 -- Text
 instance FromHttpApiData VerificationToken where

--- a/src/ZoomHub/Utils.hs
+++ b/src/ZoomHub/Utils.hs
@@ -1,6 +1,5 @@
 module ZoomHub.Utils
-  ( (<$$>),
-    intercalate,
+  ( intercalate,
     lenientDecodeUtf8,
   )
 where
@@ -10,11 +9,6 @@ import Data.List (intersperse)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
-
--- Operators:
--- See: https://mail.haskell.org/pipermail/libraries/2010-April/013417.html
-(<$$>) :: (Functor f) => f a -> (a -> b) -> f b
-(<$$>) = flip (<$>)
 
 intercalate :: Monoid a => a -> [a] -> a
 intercalate xs xss = mconcat (intersperse xs xss)

--- a/src/ZoomHub/Web/Main.hs
+++ b/src/ZoomHub/Web/Main.hs
@@ -18,6 +18,7 @@ import qualified Data.Text as T
 import Data.Time.Units (Second, toMicroseconds)
 import Data.Time.Units.Instances ()
 import GHC.Conc (getNumProcessors)
+import qualified Network.AWS as AWS
 import Network.HostName (getHostName)
 import Network.URI (parseAbsoluteURI)
 import Network.Wai (Request)
@@ -44,7 +45,7 @@ import ZoomHub.Config
   ( Config (..),
     defaultPort,
   )
-import qualified ZoomHub.Config.AWS as AWS
+import qualified ZoomHub.Config.AWS as AWSConfig
 import ZoomHub.Config.ProcessContent (ProcessContent (..))
 import qualified ZoomHub.Config.ProcessContent as ProcessContent
 import ZoomHub.Config.Uploads (Uploads (..))
@@ -117,7 +118,7 @@ main = do
   aws <-
     fromMaybe
       (error "ZoomHub.Main: Failed to parse AWS configuration.")
-      <$> AWS.fromEnv
+      <$> AWS.fromEnv AWS.Ohio -- TODO: Grab AWS region from environment?
   let port = fromMaybe defaultPort (lookup portEnvName env >>= readMaybe)
       maybeProcessContent = ProcessContent.parse <$> lookup processContentEnvName env
       processContent = fromMaybe ProcessNoContent maybeProcessContent

--- a/src/ZoomHub/Web/Main.hs
+++ b/src/ZoomHub/Web/Main.hs
@@ -50,6 +50,7 @@ import ZoomHub.Config.ProcessContent (ProcessContent (..))
 import qualified ZoomHub.Config.ProcessContent as ProcessContent
 import ZoomHub.Config.Uploads (Uploads (..))
 import qualified ZoomHub.Config.Uploads as Uploads
+import qualified ZoomHub.Log.LogLevel as LogLevel
 import ZoomHub.Log.Logger (logException_, logInfo, logInfo_)
 import ZoomHub.Log.RequestLogger (formatAsJSON)
 import ZoomHub.Storage.PostgreSQL (createConnectionPool)
@@ -119,6 +120,7 @@ main = do
     fromMaybe
       (error "ZoomHub.Main: Failed to parse AWS configuration.")
       <$> AWSConfig.fromEnv AWS.Ohio -- TODO: Grab AWS region from environment?
+  let logLevel = fromMaybe LogLevel.Debug $ lookup "LOG_LEVEL" env >>= LogLevel.parse
   let port = fromMaybe defaultPort (lookup portEnvName env >>= readMaybe)
       maybeProcessContent = ProcessContent.parse <$> lookup processContentEnvName env
       processContent = fromMaybe ProcessNoContent maybeProcessContent

--- a/src/ZoomHub/Web/Main.hs
+++ b/src/ZoomHub/Web/Main.hs
@@ -118,7 +118,7 @@ main = do
   aws <-
     fromMaybe
       (error "ZoomHub.Main: Failed to parse AWS configuration.")
-      <$> AWS.fromEnv AWS.Ohio -- TODO: Grab AWS region from environment?
+      <$> AWSConfig.fromEnv AWS.Ohio -- TODO: Grab AWS region from environment?
   let port = fromMaybe defaultPort (lookup portEnvName env >>= readMaybe)
       maybeProcessContent = ProcessContent.parse <$> lookup processContentEnvName env
       processContent = fromMaybe ProcessNoContent maybeProcessContent

--- a/src/ZoomHub/Worker.hs
+++ b/src/ZoomHub/Worker.hs
@@ -66,7 +66,7 @@ processExistingContent Config {..} workerId = forever $ do
           [ "wwwURL" .= wwwURL content,
             "apiURL" .= apiURL content
           ]
-        ZHAWS.run aws $ do
+        ZHAWS.run aws logLevel $ do
           response <-
             AWS.send $
               AWS.invoke

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ extra-deps:
   - amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
   - amazonka-core-1.6.1@sha256:9bc59ce403c6eeba3b3eaf3f10e5f0b6a33b6edbbf8f6de0dd6f4c67b86fa698,5135
   - amazonka-lambda-1.6.1@sha256:395f48418da98b6c8853c7751e08464eee7b9140683c0b6f19b54c4b21699b5d,4231
+  - amazonka-ses-1.6.1@sha256:335796c855121ca34affd35097676587d5ebe0b2e576da42faaedd9d163881b0,6425
   - mime-0.4.0.2
   - squeal-postgresql-0.5.1.0
   - time-units-1.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,6 +26,13 @@ packages:
   original:
     hackage: amazonka-lambda-1.6.1@sha256:395f48418da98b6c8853c7751e08464eee7b9140683c0b6f19b54c4b21699b5d,4231
 - completed:
+    hackage: amazonka-ses-1.6.1@sha256:335796c855121ca34affd35097676587d5ebe0b2e576da42faaedd9d163881b0,6425
+    pantry-tree:
+      size: 18151
+      sha256: 1b4746acac660d5418731b3972c4ff2285ee3435c709dfda67df49665f781d0a
+  original:
+    hackage: amazonka-ses-1.6.1@sha256:335796c855121ca34affd35097676587d5ebe0b2e576da42faaedd9d163881b0,6425
+- completed:
     hackage: mime-0.4.0.2@sha256:208947d9d1a19d08850be67ecb28c6e776db697f3bba05bd9d682e51a59f241f,983
     pantry-tree:
       size: 565

--- a/tests/ZoomHub/APISpec.hs
+++ b/tests/ZoomHub/APISpec.hs
@@ -45,6 +45,7 @@ import qualified ZoomHub.Config as Config
 import qualified ZoomHub.Config.AWS as AWSConfig
 import ZoomHub.Config.ProcessContent (ProcessContent (ProcessExistingAndNewContent))
 import ZoomHub.Config.Uploads (Uploads (UploadsDisabled))
+import qualified ZoomHub.Log.LogLevel as LogLevel
 import ZoomHub.Storage.PostgreSQL (createConnectionPool, getById)
 import qualified ZoomHub.Storage.PostgreSQL as ConnectInfo (fromEnv)
 import ZoomHub.Storage.PostgreSQL.Internal (destroyAllResources)
@@ -163,6 +164,7 @@ config =
       environment = Environment.Test,
       error404 = "404",
       logger = nullLogger,
+      logLevel = LogLevel.Debug,
       openSeadragonScript = "osd",
       port = 8000,
       processContent = ProcessExistingAndNewContent,

--- a/tests/ZoomHub/APISpec.hs
+++ b/tests/ZoomHub/APISpec.hs
@@ -17,6 +17,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Base64 as T
 import Data.Time.Units (Second)
+import qualified Network.AWS as AWS
 import Network.HTTP.Types (hAuthorization, hContentType, methodGet, methodPut)
 import Network.URI (URI, parseURIReference)
 import Network.Wai (Middleware)
@@ -41,6 +42,7 @@ import Text.RawString.QQ (r)
 import ZoomHub.API (app)
 import ZoomHub.Config (Config (..))
 import qualified ZoomHub.Config as Config
+import qualified ZoomHub.Config.AWS as AWSConfig
 import ZoomHub.Config.ProcessContent (ProcessContent (ProcessExistingAndNewContent))
 import ZoomHub.Config.Uploads (Uploads (UploadsDisabled))
 import ZoomHub.Storage.PostgreSQL (createConnectionPool, getById)
@@ -147,7 +149,8 @@ config :: Config
 config =
   Config
     { apiUser = authorizedUser,
-      aws = undefined, -- TODO: Test AWS functionality
+      -- TODO: How can we avoid `unsafePerformIO`?
+      aws = fromJust $ unsafePerformIO $ AWSConfig.fromEnv AWS.Ohio,
       baseURI = BaseURI (toURI "http://localhost:8000"),
       contentBaseURI = case mkContentBaseURI (toURI "http://localhost:9000/_dzis_") of
         Just uri -> uri

--- a/tests/ZoomHub/APISpec.hs
+++ b/tests/ZoomHub/APISpec.hs
@@ -268,7 +268,6 @@ spec = with (app config) $ afterAll_ (closeDatabaseConnection config) do
       let cId = ContentId.fromString newContentId
       maybeContent <- liftIO $ runPoolPQ (getById cId) (Config.dbConnPool config)
       let verificationToken = fromJust $ maybeContent >>= contentVerificationToken
-      liftIO $ print verificationToken
       put ("/v1/content/Xar/verification/" <> BC.pack (show verificationToken)) ""
         `shouldRespondWith` restRedirect cId
     describe "Complete content by ID (PUT /v1/content/:id/completion)" do

--- a/tests/ZoomHub/APISpec.hs
+++ b/tests/ZoomHub/APISpec.hs
@@ -187,7 +187,7 @@ config =
           dbConnPoolIdleTime'
           dbConnPoolMaxResourcesPerStripe'
     dbConnPoolIdleTime' = 10 :: Second
-    dbConnPoolMaxResourcesPerStripe' = (numCapabilities * 2) + numSpindles
+    dbConnPoolMaxResourcesPerStripe' = numCapabilities * 2 + numSpindles
     dbConnPoolNumStripes' = 1
 
 closeDatabaseConnection :: Config -> IO ()
@@ -227,8 +227,8 @@ spec = with (app config) $ afterAll_ (closeDatabaseConnection config) do
         liftIO do
           let pool = Config.dbConnPool config
           mContent <- runPoolPQ (getById $ ContentId.fromString newContentId) pool
-          (mContent >>= contentSubmitterEmail) `shouldBe` (Just $ T.pack testEmail)
-          (mContent >>= \c -> fromIntegral . length . show <$> contentVerificationToken c) `shouldBe` (Just (36 :: Integer))
+          (mContent >>= contentSubmitterEmail) `shouldBe` Just (T.pack testEmail)
+          (mContent >>= (fmap (fromIntegral . length . show) . contentVerificationToken)) `shouldBe` Just (36 :: Integer)
         get ("/v1/content/" <> BC.pack newContentId)
           `shouldRespondWith` [r|{"dzi":null,"progress":0,"url":"http://example.com","verified":false,"embedHtml":"<script src=\"http://localhost:8000/Xar.js?width=auto&height=400px\"></script>","shareUrl":"http://localhost:8000/Xar","id":"Xar","ready":false,"failed":false}|]
             { matchStatus = 200,

--- a/tests/ZoomHub/Storage/PostgreSQLSpec.hs
+++ b/tests/ZoomHub/Storage/PostgreSQLSpec.hs
@@ -16,6 +16,7 @@ import Control.Monad (forM_, void)
 import qualified Data.ByteString.Char8 as BC
 import Data.Function ((&))
 import Data.Int (Int64)
+import Data.Maybe (fromJust)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock

--- a/tests/ZoomHub/Storage/PostgreSQLSpec.hs
+++ b/tests/ZoomHub/Storage/PostgreSQLSpec.hs
@@ -197,7 +197,7 @@ spec =
               contentNumViews content `shouldBe` 0
               contentError content `shouldBe` Nothing
               contentDZI content `shouldBe` Nothing
-              contentSubmitterEmail content `shouldBe` (Just testEmail)
+              contentSubmitterEmail content `shouldBe` Just testEmail
             Nothing ->
               expectationFailure "expected content to be initialized"
     describe "markAsActive" do

--- a/zh
+++ b/zh
@@ -97,12 +97,8 @@ test)
     # See: https://github.com/commercialhaskell/stack/issues/2210
     MODULES="$2"
 
-    ZH_ENV='test' \
     PGUSER="$(whoami)" \
     PGDATABASE="$TEST_DB_NAME" \
-    AWS_ACCESS_KEY_ID='<TEST>' \
-    AWS_SECRET_ACCESS_KEY='<TEST>' \
-    S3_SOURCES_BUCKET='<TEST>' \
       stack test \
         --fast \
         --ghc-options='-Wall' \

--- a/zh
+++ b/zh
@@ -61,9 +61,10 @@ run)
     createdb "$DEVELOPMENT_DB_NAME"
 
     PGUSER="$(whoami)" HASHIDS_SALT='secret-salt' \
-      stack build --no-run-tests \
-                  --ghc-options='-Wall' \
-                  --exec "migrate-database $DEVELOPMENT_DB_NAME migrate"
+      stack build \
+        --no-run-tests \
+        --ghc-options='-Wall' \
+        --exec "migrate-database $DEVELOPMENT_DB_NAME migrate"
 
     # NOTE: Preserves existing content IDs:
     DISABLE_PG_TRIGGERS='SET session_replication_role = replica;'
@@ -72,10 +73,11 @@ run)
     psql --output /dev/null --quiet "$DEVELOPMENT_DB_NAME" \
       < ./data/zoomhub_sequences.sql
 
-    stack build --no-run-tests \
-                --ghc-options='-Wall' \
-                --file-watch \
-                --exec ./scripts/run-development.sh
+    stack build \
+      --no-run-tests \
+      --ghc-options='-Wall' \
+      --file-watch \
+      --exec ./scripts/run-development.sh
     ;;
 test)
     dropdb --if-exists "$TEST_DB_NAME"

--- a/zh
+++ b/zh
@@ -98,6 +98,9 @@ test)
     ZH_ENV='test' \
     PGUSER="$(whoami)" \
     PGDATABASE="$TEST_DB_NAME" \
+    AWS_ACCESS_KEY_ID='<TEST>' \
+    AWS_SECRET_ACCESS_KEY='<TEST>' \
+    S3_SOURCES_BUCKET='<TEST>' \
       stack test \
         --fast \
         --ghc-options='-Wall' \

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -98,6 +98,7 @@ library
     , amazonka-ses
     , async
     , atomic-write
+    , binary
     , blaze-builder
     , bytestring
     , case-insensitive

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -197,6 +197,7 @@ test-suite tests
   build-depends:
       base
     , aeson
+    , amazonka
     , base64
     , bytestring
     , generics-sop

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -91,6 +91,7 @@ library
     , aeson-pretty
     , amazonka
     , amazonka-lambda
+    , amazonka-ses
     , async
     , atomic-write
     , blaze-builder

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -43,6 +43,7 @@ library
     , ZoomHub.Email
     , ZoomHub.Email.Verification
     , ZoomHub.Log.Logger
+    , ZoomHub.Log.LogLevel
     , ZoomHub.Log.RequestLogger
     , ZoomHub.Servant.RawCapture
     , ZoomHub.Servant.RequiredQueryParam

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -40,6 +40,8 @@ library
     , ZoomHub.Config.ProcessContent
     , ZoomHub.Config.Uploads
     , ZoomHub.Debug
+    , ZoomHub.Email
+    , ZoomHub.Email.Verification
     , ZoomHub.Log.Logger
     , ZoomHub.Log.RequestLogger
     , ZoomHub.Servant.RawCapture

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -34,6 +34,7 @@ library
     , ZoomHub.API.Types.DeepZoomImageWithoutURL
     , ZoomHub.API.Types.JSONP
     , ZoomHub.API.Types.NonRESTfulResponse
+    , ZoomHub.AWS
     , ZoomHub.Config
     , ZoomHub.Config.AWS
     , ZoomHub.Config.ProcessContent


### PR DESCRIPTION
- Send submitter an email with a verification link to authenticate the upload.
  After verification, our background worker picks up unprocessed submissions and
  processes them via AWS Lambda.
- Introduce `ZH_ENV = "development" | "test" | "production"` environment
  variable for controlling certain actions, e.g. not sending emails during
  testing.
- Set content version to `5` on new submissions. These are submissions that
  have a submitter email and verification token.
- Control logging via `LOG_LEVEL` environment variable. Extract `LogLevel`
  module and introduce `logLevel` configuration for controlling what level of
  logs we want to capture.
- Pipe AWS logs through our own JSON logger.
- Reduce log level of many worker operations to reduce noise.
- Remove unused `S3_CACHE_BUCKET` from Haskell web server.