### PR TITLE
Enable S3 uploads via HTTPS

### DIFF
--- a/scripts/run-development.sh
+++ b/scripts/run-development.sh
@@ -25,7 +25,7 @@ PGDATABASE='zoomhub_development' \
 PGUSER="$(whoami)" \
 PROCESS_CONTENT='ProcessExistingAndNewContent' \
 PROCESSING_WORKERS='2' \
-S3_SOURCES_BUCKET='sources-development.zoomhub.net' \
+S3_SOURCES_BUCKET='zoomhub-sources-development' \
 UPLOADS='true' \
   stack exec zoomhub | jq &
 

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -404,7 +404,7 @@ restUpload baseURI awsConfig uploads email =
       s3UploadKey <- (T.pack . show) <$> liftIO UUIDV4.nextRandom
       let expiryTime = Time.addUTCTime Time.nominalDay currentTime
           key = "uploads/" <> s3UploadKey
-          s3BucketURL = "http://" <> s3Bucket <> ".s3.us-east-2.amazonaws.com"
+          s3BucketURL = "https://" <> s3Bucket <> ".s3.us-east-2.amazonaws.com"
           s3URL = s3BucketURL <> "/" <> key
           ePolicy =
             S3.newPostPolicy


### PR DESCRIPTION
Create new S3 buckets with names that don’t have periods in them so that they can be accessed via HTTPS.