### PR TITLE
Reset content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [#172][zh-22] Auto-rotate images based on EXIF data.
 - Worker: Increase poll interval from 3 to 5 seconds.
+- Add `PUT /v1/content/:id/reset` for admins to reset content, e.g. after it
+  failed or we improved the processing pipeline. An example is for images that
+  were incorrectly rotated but can be reprocessed after fixing that issue
+  [#172][zh-22].
+- Ensure running and testing the app doesn’t cause a full rebuild by matching
+  `stack` (GHC) flags.
 
 ## 2021-09-25
 

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -610,7 +610,7 @@ webContentVerificationById baseURI contentBaseURI dbConnPool contentId verificat
   case result of
     Right internalContent -> do
       let content = Content.fromInternal baseURI contentBaseURI internalContent
-      return $ Page.mkVerifyContent baseURI (VerificationResult.Success $ content)
+      return $ Page.mkVerifyContent baseURI (VerificationResult.Success content)
     Left VerificationError.TokenMismatch ->
       return $ Page.mkVerifyContent baseURI (VerificationResult.Error "Cannot verify submission :(")
     Left VerificationError.ContentNotFound ->

--- a/src/ZoomHub/Authentication.hs
+++ b/src/ZoomHub/Authentication.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module ZoomHub.Authentication
+  ( AuthenticatedUser,
+    check,
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+import Servant (BasicAuthData (BasicAuthData))
+import Servant.Auth.Server (AuthResult (Authenticated, NoSuchUser), BasicAuthCfg, FromBasicAuthData (fromBasicAuthData), FromJWT, ToJWT)
+import ZoomHub.Types.APIUser (APIUser (APIUser))
+import qualified ZoomHub.Types.APIUser as APIUser
+import ZoomHub.Utils (lenientDecodeUtf8)
+
+data AuthenticatedUser = AuthenticatedUser
+  deriving (Show, Generic)
+
+instance ToJSON AuthenticatedUser
+
+instance FromJSON AuthenticatedUser
+
+instance ToJWT AuthenticatedUser
+
+instance FromJWT AuthenticatedUser
+
+type instance BasicAuthCfg = BasicAuthData -> IO (AuthResult AuthenticatedUser)
+
+check :: APIUser -> BasicAuthData -> IO (AuthResult AuthenticatedUser)
+check apiUser (BasicAuthData unverifiedUsername unverifiedPassword) =
+  let username = APIUser.username apiUser
+      password = APIUser.password apiUser
+   in if username == lenientDecodeUtf8 unverifiedUsername
+        && password == lenientDecodeUtf8 unverifiedPassword
+        then pure $ Authenticated AuthenticatedUser
+        else pure NoSuchUser
+
+instance FromBasicAuthData AuthenticatedUser where
+  fromBasicAuthData authData checkFunction = checkFunction authData

--- a/src/ZoomHub/Storage/PostgreSQL/Internal.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Internal.hs
@@ -549,6 +549,7 @@ markContentAsVerified =
   update
     #content
     ( Set currentTimestamp `as` #verified_at
+        :* Set (literal Content.version) `as` #version
     )
     (#hash_id .== param @1)
     ( Returning_

--- a/src/ZoomHub/Storage/PostgreSQL/Internal.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Internal.hs
@@ -586,8 +586,8 @@ resetContentAsInitialized =
         :* Set null_ `as` #completed_at
         :* Set null_ `as` #mime
         :* Set null_ `as` #size
-        :* Set null_ `as` #error
-        :* Set 0.0 `as` #progress -- reset any previous errors
+        :* Set null_ `as` #error -- reset any previous errors
+        :* Set 0.0 `as` #progress
     )
     (#hash_id .== param @1)
     ( Returning_

--- a/src/ZoomHub/Types/APIUser.hs
+++ b/src/ZoomHub/Types/APIUser.hs
@@ -5,4 +5,7 @@ where
 
 import Data.Text (Text)
 
-data APIUser = APIUser {username :: Text, password :: Text}
+data APIUser = APIUser
+  { username :: Text,
+    password :: Text
+  }

--- a/tests/ZoomHub/APISpec.hs
+++ b/tests/ZoomHub/APISpec.hs
@@ -256,7 +256,8 @@ spec = with (app config) $ afterAll_ (closeDatabaseConnection config) do
             { matchStatus = 404,
               matchHeaders = [plainTextUTF8]
             }
-    describe "Verify content by ID (GET /v1/content/:id/verification/:token)" do
+
+    describe "Verify content by ID (PUT /v1/content/:id/verification/:token)" do
       it "should return 404 non-existent content" $
         put "/v1/content/nonExistentContent/verification/00000000-0000-0000-0000-000000000000" ""
           `shouldRespondWith` "No content with ID: nonExistentContent"

--- a/zh
+++ b/zh
@@ -62,6 +62,7 @@ run)
 
     PGUSER="$(whoami)" HASHIDS_SALT='secret-salt' \
       stack build \
+        --fast \
         --no-run-tests \
         --ghc-options='-Wall' \
         --exec "migrate-database $DEVELOPMENT_DB_NAME migrate"

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -35,6 +35,7 @@ library
     , ZoomHub.API.Types.DeepZoomImageWithoutURL
     , ZoomHub.API.Types.JSONP
     , ZoomHub.API.Types.NonRESTfulResponse
+    , ZoomHub.Authentication
     , ZoomHub.AWS
     , ZoomHub.Config
     , ZoomHub.Config.AWS


### PR DESCRIPTION
## 2021-09-26

- #172 Auto-rotate images based on EXIF data.
- Worker: Increase poll interval from 3 to 5 seconds.
- Add `PUT /v1/content/:id/reset` for admins to reset content, e.g. after it
  failed or we improved the processing pipeline. An example is for images that
  were incorrectly rotated but can be reprocessed after fixing that issue
  #172.
- Ensure running and testing the app doesn’t cause a full rebuild by matching
  `stack` (GHC) flags.