### PR TITLE
Improve `getNextUnprocessed` query performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2021-09-28
 
+- Improve performance of `getNextUnprocessed` query using indexes on `content`.
 - When resetting content, delete any associated image.
 - Temporarily reduce max upload size from 100MB to 50MB due to AWS Lambda
   scratch disk limitations (500MB maximum).

--- a/src/ZoomHub/Storage/PostgreSQL.hs
+++ b/src/ZoomHub/Storage/PostgreSQL.hs
@@ -45,7 +45,7 @@ import qualified Data.UUID.V4 as UUIDV4
 import Squeal.PostgreSQL
   ( MonadPQ,
     Only (Only),
-    SortExpression (Asc, Desc),
+    SortExpression (Asc, Desc, DescNullsLast),
     firstRow,
     getRows,
     isNotNull,
@@ -146,6 +146,7 @@ getExpiredActive ttl = do
                   ( ((#content ! #active_at) .< param @1)
                       .&& ((#content ! #state) .== literal Active)
                   )
+                & orderBy [#content ! #active_at & DescNullsLast]
           )
       )
       (Only earliestAllowed)

--- a/src/ZoomHub/Storage/PostgreSQL.hs
+++ b/src/ZoomHub/Storage/PostgreSQL.hs
@@ -116,16 +116,18 @@ getNextUnprocessed = do
   result <-
     runQueryParams
       ( selectContentBy $
-          \t ->
-            t
+          \table ->
+            table
               & where_
                 ( (#content ! #state) .== param @1
                     .&& ( #content ! #version .>= 5
                             .&& isNotNull (#content ! #verified_at)
                         )
                 )
-              & orderBy [#content ! #initialized_at & Asc]
-              & orderBy [#content ! #num_views & Desc]
+              & orderBy
+                [ #content ! #initialized_at & Asc,
+                  #content ! #num_views & Desc
+                ]
               & limit 1
       )
       (Only Initialized)

--- a/src/ZoomHub/Storage/PostgreSQL/Schema.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Schema.hs
@@ -20,10 +20,11 @@ import Squeal.PostgreSQL.Migration (Migration (..))
 import qualified ZoomHub.Storage.PostgreSQL.Schema.Schema0 as Schema0
 import qualified ZoomHub.Storage.PostgreSQL.Schema.Schema1 as Schema1
 import qualified ZoomHub.Storage.PostgreSQL.Schema.Schema2 as Schema2
-import ZoomHub.Storage.PostgreSQL.Schema.Schema3 (Schema3)
 import qualified ZoomHub.Storage.PostgreSQL.Schema.Schema3 as Schema3
+import ZoomHub.Storage.PostgreSQL.Schema.Schema4 (Schema4)
+import qualified ZoomHub.Storage.PostgreSQL.Schema.Schema4 as Schema4
 
-type Schemas = Public Schema3
+type Schemas = Public Schema4
 
 migrations :: String -> AlignedList (Migration Definition) (Public '[]) Schemas
 migrations hashidsSecret =
@@ -31,4 +32,5 @@ migrations hashidsSecret =
     >>> Schema1.migration
     :>> Schema2.migration
     :>> Schema3.migration
+    :>> Schema4.migration
     :>> Done

--- a/src/ZoomHub/Storage/PostgreSQL/Schema/Schema4.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Schema/Schema4.hs
@@ -42,6 +42,7 @@ setup =
   manipDefinition $
     UnsafeManipulation
       [r|
+        CREATE INDEX "content_active_at_idx" ON "content" USING btree ("active_at");
         CREATE INDEX "content_initialized_at_idx" ON "content" USING btree ("initialized_at");
         CREATE INDEX "content_num_views_idx" ON "content" USING btree ("num_views" DESC NULLS LAST);
         CREATE INDEX "content_state_idx" ON "content" USING btree ("state");
@@ -55,6 +56,7 @@ teardown =
   manipDefinition $
     UnsafeManipulation
       [r|
+        DROP INDEX "content_active_at_idx";
         DROP INDEX "content_initialized_at_idx";
         DROP INDEX "content_num_views_idx";
         DROP INDEX "content_state_idx";

--- a/src/ZoomHub/Storage/PostgreSQL/Schema/Schema4.hs
+++ b/src/ZoomHub/Storage/PostgreSQL/Schema/Schema4.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+{-# OPTIONS_GHC -fomit-interface-pragmas #-}
+
+module ZoomHub.Storage.PostgreSQL.Schema.Schema4
+  ( Schema4,
+    migration,
+  )
+where
+
+import Squeal.PostgreSQL
+  ( Definition,
+    Manipulation (UnsafeManipulation),
+    Public,
+    manipDefinition,
+  )
+import Squeal.PostgreSQL.Migration (Migration (..))
+import Text.RawString.QQ (r)
+import ZoomHub.Storage.PostgreSQL.Schema.Schema3 (Schema3)
+
+type Schema4 = Schema3
+
+type Schemas4 = Public Schema4
+
+migration :: Migration Definition Schemas4 Schemas4
+migration =
+  Migration
+    { name = "2021-09-28-1: Add content indexes",
+      up = setup,
+      down = teardown
+    }
+
+-- TODO: Use `createIndex` once we upgraded to Squeal 0.6:
+setup :: Definition Schemas4 Schemas4
+setup =
+  manipDefinition $
+    UnsafeManipulation
+      [r|
+        CREATE INDEX "content_initialized_at_idx" ON "content" USING btree ("initialized_at");
+        CREATE INDEX "content_num_views_idx" ON "content" USING btree ("num_views" DESC NULLS LAST);
+        CREATE INDEX "content_state_idx" ON "content" USING btree ("state");
+        CREATE INDEX "content_verified_at_idx" ON "content" USING btree ("verified_at");
+        CREATE INDEX "content_version_idx" ON "content" USING btree ("version" DESC NULLS LAST);
+      |]
+
+-- TODO: Use `dropIndex` once we upgraded to Squeal 0.6:
+teardown :: Definition Schemas4 Schemas4
+teardown =
+  manipDefinition $
+    UnsafeManipulation
+      [r|
+        DROP INDEX "content_initialized_at_idx";
+        DROP INDEX "content_num_views_idx";
+        DROP INDEX "content_state_idx";
+        DROP INDEX "content_verified_at_idx";
+        DROP INDEX "content_version_idx";
+      |]

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -57,6 +57,7 @@ library
     , ZoomHub.Storage.PostgreSQL.Schema.Schema1
     , ZoomHub.Storage.PostgreSQL.Schema.Schema2
     , ZoomHub.Storage.PostgreSQL.Schema.Schema3
+    , ZoomHub.Storage.PostgreSQL.Schema.Schema4
     , ZoomHub.Types.APIUser
     , ZoomHub.Types.BaseURI
     , ZoomHub.Types.Content


### PR DESCRIPTION
Add indexes to speed up the slowest query, i.e. `getNextUnprocessed`:

```sql
SELECT
    "content"."hash_id" AS "cirHashId",
    "content"."type_id" AS "cirTypeId",
    "content"."url" AS "cirURL",
    "content"."state" AS "cirState",
    "content"."initialized_at" AS "cirInitializedAt",
    "content"."active_at" AS "cirActiveAt",
    "content"."completed_at" AS "cirCompletedAt",
    "content"."title" AS "cirTitle",
    "content"."attribution_text" AS "cirAttributionText",
    "content"."attribution_link" AS "cirAttributionLink",
    "content"."mime" AS "cirMIME",
    "content"."size" AS "cirSize",
    "content"."error" AS "cirError",
    "content"."progress" AS "cirProgress",
    "content"."abuse_level_id" AS "cirAbuseLevelId",
    "content"."num_abuse_reports" AS "cirNumAbuseReports",
    "content"."num_views" AS "cirNumViews",
    "content"."version" AS "cirVersion",
    "content"."submitter_email" AS "cirSubmitterEmail",
    "content"."verification_token" AS "cirVerificationToken",
    "content"."verified_at" AS "cirVerifiedAt",
    "image"."width" AS "cirWidth",
    "image"."height" AS "cirHeight",
    "image"."tile_size" AS "cirTileSize",
    "image"."tile_overlap" AS "cirTileOverlap",
    "image"."tile_format" AS "cirTileFormat"
FROM
    "content" AS "content"
    LEFT OUTER JOIN "image" AS "image" ON ("content"."id" = "image"."content_id")
WHERE (("content"."state" = ($1::text))
    AND (("content"."version" >= 5)
        AND "content"."verified_at" IS NOT NULL))
ORDER BY
    "content"."initialized_at" ASC,
    "content"."num_views" DESC
LIMIT 1;
```