### PR TITLE
Reset expired active content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Improve performance of `getNextUnprocessed` query using indexes on `content`.
 - When resetting content, delete any associated image.
+- Reset content that hasn’t completed processing within 30 minutes (expired
+  active content).
 - Temporarily reduce max upload size from 100MB to 50MB due to AWS Lambda
   scratch disk limitations (500MB maximum).
 - Improve logging for when we try to notify someone about content without a


### PR DESCRIPTION
Content that hasn’t completed processing in 30 minutes will be reset by this background worker.

**TODO**
- [ ] Prevent infinite loops that will cost AWS resources. Impose limit on how many times we try to convert an image before we give up.