### PR TITLE
2021-09-29-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ZoomHub
 
+## 2021-09-29
+
+- Redirect on verification link if content is completed.
+- Improve copy of verification email.
+- Homepage: Keep upload card in view (via scrolling) when changing states.
+- Use HTTPS for static and cache content URLs by default.
+- Use `neat-interpolation` for cleaner multiline strings with interpolated
+  values.
+- `zh`: Fix slow compilation due to optimization flag change by adding `--fast`
+  to match all the other `stack build` calls.
+
 ## 2021-09-28
 
 - Improve performance of `getNextUnprocessed` query using indexes on `content`.

--- a/public/index.html
+++ b/public/index.html
@@ -593,6 +593,10 @@
             const sectionElement = document.querySelector(`.${currentSection}`)
             sectionElement.style.display =
               section === currentSection ? "block" : "none"
+            sectionElement.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+            })
           })
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -162,7 +162,7 @@
         transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
       }
 
-      p.lead {
+      .lead {
         font-size: 20px;
         line-height: 1.4em;
       }
@@ -427,14 +427,14 @@
 
         <div class="progress" style="display: none">
           <h2>⬆️ Uploading…</h2>
-          <p class="lead">Hang tight, we’re uploading your image.</p>
+          <div class="lead">Hang tight, we’re uploading your image.</div>
         </div>
 
         <div class="thanks" style="display: none">
           <h2>🎉 Success!</h2>
-          <p class="lead">
+          <div class="lead">
             📩 Check your email. We just sent you the link to view your upload
-          </p>
+          </div>
         </div>
       </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -433,7 +433,7 @@
         <div class="thanks" style="display: none">
           <h2>🎉 Success!</h2>
           <div class="lead">
-            📩 Check your email. We just sent you the link to view your upload
+            📩 Check your email. We just sent you the link to view your upload.
           </div>
         </div>
       </div>

--- a/scripts/run-development.sh
+++ b/scripts/run-development.sh
@@ -20,7 +20,7 @@ fi
 
 ZH_ENV='development' \
 BASE_URI="${BASE_URI:-http://localhost:8000}" \
-CONTENT_BASE_URI='http://cache-development.zoomhub.net/content' \
+CONTENT_BASE_URI='https://cache-development.zoomhub.net/content' \
 PGDATABASE='zoomhub_development' \
 PGUSER="$(whoami)" \
 PROCESS_CONTENT='ProcessExistingAndNewContent' \

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -118,6 +118,7 @@ import ZoomHub.Types.BaseURI (BaseURI, unBaseURI)
 import qualified ZoomHub.Types.Content as Internal
 import ZoomHub.Types.ContentBaseURI (ContentBaseURI)
 import ZoomHub.Types.ContentId (ContentId, unContentId)
+import qualified ZoomHub.Types.ContentState as ContentState
 import ZoomHub.Types.ContentURI (ContentURI)
 import qualified ZoomHub.Types.Environment as Environment
 import ZoomHub.Types.StaticBaseURI (StaticBaseURI)
@@ -659,6 +660,8 @@ webContentVerificationById ::
 webContentVerificationById baseURI contentBaseURI dbConnPool contentId verificationToken = do
   result <- liftIO $ runPoolPQ (PG.markAsVerified contentId verificationToken) dbConnPool
   case result of
+    Right internalContent | ContentState.isCompleted (Internal.contentState internalContent) -> do
+      redirectToView baseURI (Internal.contentId internalContent)
     Right internalContent -> do
       let content = Content.fromInternal baseURI contentBaseURI internalContent
       return $ Page.mkVerifyContent baseURI (VerificationResult.Success content)
@@ -692,8 +695,10 @@ webContentByURL ::
 webContentByURL baseURI dbConnPool contentURI = do
   maybeContent <- liftIO $ runPoolPQ (PG.getByURL contentURI) dbConnPool
   case maybeContent of
-    Nothing -> noNewContentErrorWeb
-    Just c -> redirectToView baseURI (Internal.contentId c)
+    Nothing ->
+      noNewContentErrorWeb
+    Just content ->
+      redirectToView baseURI (Internal.contentId content)
 
 webInvalidURLParam :: String -> Handler Page.ViewContent
 webInvalidURLParam _ = throwError . Web.error400 $ invalidURLErrorMessage
@@ -740,7 +745,7 @@ invalidURLErrorMessage :: String
 invalidURLErrorMessage =
   "Please give us the full URL, including ‘http://’ or ‘https://’."
 
-redirectToView :: BaseURI -> ContentId -> Handler Page.ViewContent
+redirectToView :: BaseURI -> ContentId -> Handler a
 redirectToView baseURI contentId =
   -- TODO: Look into Servant ‘Links’ for type safe link generation:
   redirect $ webRedirectURI baseURI contentId

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -596,7 +596,7 @@ restContentByURL config baseURI dbConnPool processContent url mEmail = do
             baseURI
             contentId
             verificationToken
-            (Email.From "\"ZoomHub\" <daniel@zoomhub.net>")
+            (Email.From "\"ZoomHub (formerly zoom.it)\" <daniel@zoomhub.net>")
             (Email.To submitterEmail)
 
 restInvalidRequest :: Maybe String -> Handler Content

--- a/src/ZoomHub/Email/Verification.hs
+++ b/src/ZoomHub/Email/Verification.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module ZoomHub.Email.Verification
   ( request,
@@ -7,6 +8,7 @@ module ZoomHub.Email.Verification
 where
 
 import qualified Data.Text as T
+import NeatInterpolation (text)
 import ZoomHub.Email (Email (..), From, To)
 import ZoomHub.Types.BaseURI (BaseURI)
 import ZoomHub.Types.ContentId (ContentId, unContentId)
@@ -17,22 +19,23 @@ request :: BaseURI -> ContentId -> VerificationToken -> From -> To -> Email
 request baseURI contentId verificationToken from to =
   Email {from, to, subject, body}
   where
-    subject = "ZoomHub: View your upload"
+    subject = "View your upload"
     body =
-      "Hi,\n\
-      \\n\
-      \Thanks for your upload to ZoomHub (formerly zoom.it).\n\
-      \\n\
-      \You can now view it at: "
-        <> verificationURL
-        <> "\n\n\
-           \If you haven’t uploaded anything to ZoomHub, please ignore this email.\n\
-           \\n\
-           \Thanks,\n\
-           \Daniel from ZoomHub\n\
-           \\n\
-           \\n\
-           \P.S. If you have any questions or feedback, simply reply to this email. I read each and every message :)"
+      [text|
+        Hi,
+
+        Thanks for your upload to ZoomHub (formerly zoom.it).
+
+        You can now view it at: $verificationURL
+
+        If you haven’t uploaded anything to ZoomHub, please ignore this email.
+
+        Thanks,
+        Daniel from ZoomHub
+
+
+        P.S. Do you have a question or feedback? Simply reply to this email. I read each and every message :)
+      |]
     verificationURL =
       T.pack (show baseURI)
         <> "/"

--- a/src/ZoomHub/Types/ContentState.hs
+++ b/src/ZoomHub/Types/ContentState.hs
@@ -8,6 +8,7 @@
 module ZoomHub.Types.ContentState
   ( ContentState (..),
     fromString,
+    isCompleted,
   )
 where
 
@@ -43,6 +44,13 @@ toText Initialized = "initialized"
 toText Active = "active"
 toText CompletedSuccess = "completed:success"
 toText CompletedFailure = "completed:failure"
+
+isCompleted :: ContentState -> Bool
+isCompleted state = case state of
+  Initialized -> False
+  Active -> False
+  CompletedSuccess -> True
+  CompletedFailure -> True
 
 -- Squeal / PostgreSQL
 instance FromValue 'PGtext ContentState where

--- a/src/ZoomHub/Web/Main.hs
+++ b/src/ZoomHub/Web/Main.hs
@@ -114,7 +114,7 @@ main = do
           toBaseURI uriString
         Nothing ->
           toBaseURI $ "http://" <> hostname
-      defaultStaticBaseURI = StaticBaseURI . fromJust . parseAbsoluteURI $ "http://static.zoomhub.net"
+      defaultStaticBaseURI = StaticBaseURI . fromJust . parseAbsoluteURI $ "https://static.zoomhub.net"
       mStaticBaseURI = StaticBaseURI <$> (parseAbsoluteURI =<< lookup "STATIC_BASE_URI" env)
       staticBaseURI = fromMaybe defaultStaticBaseURI mStaticBaseURI
       defaultDBName = "zoomhub_development"

--- a/src/ZoomHub/Web/Page.hs
+++ b/src/ZoomHub/Web/Page.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module ZoomHub.Web.Page
@@ -6,8 +7,6 @@ module ZoomHub.Web.Page
     title,
     styles,
     analyticsScript,
-    -- TODO: Hide
-    concatPretty,
   )
 where
 
@@ -31,6 +30,7 @@ import Lucid
     title_,
     toHtml,
   )
+import NeatInterpolation (text)
 
 title :: Text
 title = "ZoomHub · Share and view high-resolution images effortlessly"
@@ -98,66 +98,61 @@ template pageTitle body = do
         )
       body_ $ body
 
--- HTML
-concatPretty :: [Text] -> Text
-concatPretty = T.intercalate "\n"
-
 -- TODO: Improve how we represent inline styles.
 styles :: Text
 styles =
-  concatPretty
-    [ "html, body {",
-      "  background-color: black;",
-      "  color: white;",
-      "  font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif;",
-      "  font-size: 16px;",
-      "  height: 100%;",
-      "  margin: 0;",
-      "  padding: 0;",
-      "}",
-      ".meta {",
-      "  align-items: center;",
-      "  bottom: 0;",
-      "  color: white;",
-      "  display: flex;",
-      "  font-size: 12px;",
-      "  justify-content: center;",
-      "  left: 0;",
-      "  padding: 1em 3em;",
-      "  position: fixed;",
-      "  right: 0;",
-      "}",
-      ".meta a,",
-      ".meta a:visited {",
-      "  font-family: monospace;",
-      "  color: #666;",
-      "}",
-      ".meta a:hover {",
-      "  color: #ddd;",
-      "}",
-      "a,",
-      ".a:visited {",
-      "  font-family: monospace;",
-      "  color: #f60;",
-      "}",
-      ".meta a:hover {",
-      "  color: #fff;",
-      "  text-decoration: underline;",
-      "}"
-    ]
+  [text|
+    html, body {
+      background-color: black;
+      color: white;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+    .meta {
+      align-items: center;
+      bottom: 0;
+      color: white;
+      display: flex;
+      font-size: 12px;
+      justify-content: center;
+      left: 0;
+      padding: 1em 3em;
+      position: fixed;
+      right: 0;
+    }
+    .meta a,
+    .meta a:visited {
+      font-family: monospace;
+      color: #666;
+    }
+    .meta a:hover {
+      color: #ddd;
+    }
+    a,
+    .a:visited {
+      color: #f60;
+    }
+    a:hover {
+      color: #fff;
+      text-decoration: underline;
+    }
+  |]
 
 -- TODO: Improve how we represent analytics code.
 -- TODO: Pass through `UA-XXXXXXXX-X` Google Analytics ID.
 analyticsScript :: Text
 analyticsScript =
-  concatPretty
-    [ "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){",
-      "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),",
-      "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)",
-      "})(window,document,'script','//www.google-analytics.com/analytics.js','ga');",
-      "",
-      "ga('create', 'UA-55808703-1', 'auto');",
-      "ga('_setDomainName', 'zoomhub.net');",
-      "ga('_setAllowLinker', true);",
-      "ga('send', 'pageview');"
-    ]
+  [text|
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-55808703-1', 'auto');
+    ga('_setDomainName', 'zoomhub.net');
+    ga('_setAllowLinker', true);
+    ga('send', 'pageview');
+  |]

--- a/src/ZoomHub/Web/Page.hs
+++ b/src/ZoomHub/Web/Page.hs
@@ -11,7 +11,6 @@ module ZoomHub.Web.Page
 where
 
 import Data.Text (Text)
-import qualified Data.Text as T
 import Lucid
   ( HtmlT,
     body_,

--- a/src/ZoomHub/Web/Page.hs
+++ b/src/ZoomHub/Web/Page.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module ZoomHub.Web.Page
-  ( template,
+  ( layout,
     title,
     styles,
     analyticsScript,
@@ -35,12 +35,12 @@ import NeatInterpolation (text)
 title :: Text
 title = "ZoomHub · Share and view high-resolution images effortlessly"
 
-template ::
+layout ::
   Monad m =>
   Text -> -- title
   HtmlT m a ->
   HtmlT m a
-template pageTitle body = do
+layout pageTitle body = do
   doctypehtml_ $
     do
       head_

--- a/src/ZoomHub/Web/Page/VerifyContent.hs
+++ b/src/ZoomHub/Web/Page/VerifyContent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module ZoomHub.Web.Page.VerifyContent
@@ -45,22 +46,24 @@ mkVerifyContent vcBaseURI vcResult = VerifyContent {..}
 
 progressScript :: ContentId -> Text
 progressScript cId =
-  Page.concatPretty
-    [ ";(() => {",
-      "setInterval(async () => {",
-      "    const content = await fetch(\"/v1/content/" <> T.pack (unContentId cId) <> "\").then(",
-      "      (response) => response.json()",
-      "    )",
-      "",
-      "    console.log(\"---\")",
-      "    console.log(content)",
-      "",
-      "    if (content.ready) {",
-      "      location.href = content.shareUrl",
-      "    }",
-      "  }, 2000)",
-      "})()"
-    ]
+  [text|
+    ;(() => {
+      setInterval(async () => {
+        const content = await fetch("$apiURL").then(
+          (response) => response.json()
+        )
+
+        console.log("---")
+        console.log(content)
+
+        if (content.ready) {
+          location.href = content.shareUrl
+        }
+      }, 2000)
+    })()
+  |]
+  where
+    apiURL = "/v1/content/" <> T.pack (unContentId cId)
 
 instance ToHtml VerifyContent where
   toHtml (VerifyContent {..}) =

--- a/src/ZoomHub/Web/Page/VerifyContent.hs
+++ b/src/ZoomHub/Web/Page/VerifyContent.hs
@@ -13,18 +13,9 @@ where
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
-import Lucid
-  ( ToHtml,
-    a_,
-    div_,
-    h2_,
-    href_,
-    p_,
-    script_,
-    style_,
-    toHtml,
-    toHtmlRaw,
-  )
+import Lucid (ToHtml, toHtml, toHtmlRaw)
+import qualified Lucid as H
+import NeatInterpolation (text)
 import ZoomHub.API.Types.Content (Content, contentId, contentShareUrl)
 import ZoomHub.Types.BaseURI (BaseURI)
 import ZoomHub.Types.ContentId (ContentId, unContentId)
@@ -67,9 +58,9 @@ progressScript cId =
 
 instance ToHtml VerifyContent where
   toHtml (VerifyContent {..}) =
-    Page.template Page.title do
-      div_
-        [ style_ $
+    Page.layout Page.title do
+      H.div_
+        [ H.style_ $
             T.intercalate
               ";"
               [ "display: flex",
@@ -82,22 +73,27 @@ instance ToHtml VerifyContent where
         ]
         $ case vcResult of
           Success content -> do
-            script_ $ progressScript (contentId content)
-            h2_
-              [style_ "color: #fff;"]
-              "Your upload is now being processed…"
-            p_
-              [style_ "color: #fff;"]
-              "Hang in there, this may take up to a few minutes. We’ll redirect you as soon as it’s ready."
-            a_
-              [href_ (T.pack . show $ contentShareUrl content)]
+            H.script_ $
+              progressScript (contentId content)
+            H.h1_ [H.class_ "title"] "🔧 Your upload is now being processed…"
+            H.p_
+              [H.style_ "color: #fff;"]
+              do
+                "🕐 Hang in there, this may take up to a few minutes."
+                H.br_ []
+                "➡️ We’ll redirect you as soon as it’s ready."
+            H.p_
+              [H.style_ "color: #fff;"]
+              "\x1F971 If it’s taking too long, you can also close this page and come back via:"
+            H.a_
+              [H.href_ (T.pack . show $ contentShareUrl content)]
               (toHtml . show $ contentShareUrl content)
           Error message -> do
-            h2_
-              [style_ "color: #fff;"]
+            H.h2_
+              [H.style_ "color: #fff;"]
               "Oops, something went wrong"
-            p_
-              [style_ "color: #fff;"]
-              (toHtml message)
+            H.p_
+              [H.style_ "color: #fff;"]
+              (H.toHtml message)
 
   toHtmlRaw = toHtml

--- a/src/ZoomHub/Web/Page/ViewContent.hs
+++ b/src/ZoomHub/Web/Page/ViewContent.hs
@@ -38,7 +38,7 @@ mkViewContent :: BaseURI -> Content -> ViewContent
 mkViewContent vcBaseURI vcContent = ViewContent {..}
 
 instance ToHtml ViewContent where
-  toHtml vc = Page.template
+  toHtml vc = Page.layout
     (T.pack cId <> " — " <> Page.title)
     $ do
       script_ [src_ (T.pack $ show scriptURI)] emptyScriptBody

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,7 @@ extra-deps:
   - amazonka-lambda-1.6.1@sha256:395f48418da98b6c8853c7751e08464eee7b9140683c0b6f19b54c4b21699b5d,4231
   - amazonka-ses-1.6.1@sha256:335796c855121ca34affd35097676587d5ebe0b2e576da42faaedd9d163881b0,6425
   - mime-0.4.0.2
+  - neat-interpolation-0.5.1.2
   - squeal-postgresql-0.5.1.0
   - time-units-1.0.0
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,6 +40,13 @@ packages:
   original:
     hackage: mime-0.4.0.2
 - completed:
+    hackage: neat-interpolation-0.5.1.2@sha256:6a8f04befb39c20896aed9a452f84540dd8ed37efae09a656023b151886b1262,2992
+    pantry-tree:
+      size: 566
+      sha256: 046371778d4cdf1283089d337498cee40906edf3f55ccd1d1e89ac9209d2d083
+  original:
+    hackage: neat-interpolation-0.5.1.2
+- completed:
     hackage: squeal-postgresql-0.5.1.0@sha256:731c2bc1dbf3b02ffc8a3fe2b9215655c2b8e06aa49d18cd6ae66d91de03391f,3449
     pantry-tree:
       size: 2959

--- a/zh
+++ b/zh
@@ -75,6 +75,7 @@ run)
       < ./data/zoomhub_sequences.sql
 
     stack build \
+      --fast \
       --no-run-tests \
       --ghc-options='-Wall' \
       --file-watch \

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -129,6 +129,7 @@ library
     , minio-hs
     , monad-control
     , mtl
+    , neat-interpolation
     , network
     , network-uri
     , postgresql-simple


### PR DESCRIPTION
- Redirect on verification link if content is completed.
- Improve copy of verification email.
- Homepage: Keep upload card in view (via scrolling) when changing states.
- Use HTTPS for static and cache content URLs by default.
- Use `neat-interpolation` for cleaner multiline strings with interpolated
  values.
- `zh`: Fix slow compilation due to optimization flag change by adding `--fast`
  to match all the other `stack build` calls.