### PR TITLE
Namespace ZoomHub environment variable names

### DIFF
--- a/.github/workflows/zoomhub.yml
+++ b/.github/workflows/zoomhub.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Run backend tests
         if: steps.cache-stack-binaries.outputs.cache-hit != 'true'
         run: |
-          HASHIDS_SALT='secret-salt' ./bin/migrate-database $PGDATABASE migrate
+          ZH_HASHIDS_SALT='secret-salt' ./bin/migrate-database $PGDATABASE migrate
 
           psql $PGDATABASE < data/zoomhub_data.sql
           psql $PGDATABASE < data/zoomhub_sequences.sql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # ZoomHub
 
+## 2021-10-24-1
+
+- Namespace ZoomHub specific environment variables using `ZH_` prefix. We’ve had
+  crashes on Elastic Beanstalk because `PUBLIC_PATH` environment variable was
+  unset during new deployments. This change works around the suspicion that it’s
+  a reserved environment variable name even though it couldn’t independently be
+  verified.
+
+  Affected environment variable names:
+
+  - `ZH_API_PASSWORD`
+  - `ZH_API_USERNAME`
+  - `ZH_BASE_URI`
+  - `ZH_CONTENT_BASE_URI`
+  - `ZH_HASHIDS_SALT`
+  - `ZH_LOG_LEVEL`
+  - `ZH_PROCESS_CONTENT`
+  - `ZH_PROCESSING_WORKERS`
+  - `ZH_PUBLIC_PATH`
+  - `ZH_S3_SOURCES_BUCKET`
+  - `ZH_STATIC_BASE_URI`
+  - `ZH_UPLOADS`
+
 ## 2021-10-21-1
 
 - Make homepage more mobile friendly.

--- a/app/MigrateDatabase.hs
+++ b/app/MigrateDatabase.hs
@@ -14,7 +14,7 @@ import ZoomHub.Storage.PostgreSQL.Schema (migrations)
 main :: IO ()
 main = do
   args <- getArgs
-  mHashidsSecret <- lookupEnv "HASHIDS_SALT"
+  mHashidsSecret <- lookupEnv "ZH_HASHIDS_SALT"
   case (args, mHashidsSecret) of
     ((database : rest), Just hashidsSecret) -> do
       connectInfo <- ConnectInfo.fromEnv database
@@ -24,6 +24,6 @@ main = do
               (migrations hashidsSecret)
       withArgs rest program
     (_, Nothing) ->
-      die "Missing environment variable HASHIDS_SALT"
+      die "Missing environment variable ZH_HASHIDS_SALT"
     _ ->
       die "Missing argument DATABASE"

--- a/scripts/run-api-watch.sh
+++ b/scripts/run-api-watch.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 dropdb --if-exists "$DEVELOPMENT_DB_NAME"
 createdb "$DEVELOPMENT_DB_NAME"
 
-PGUSER="$(whoami)" HASHIDS_SALT='secret-salt' \
+PGUSER="$(whoami)" ZH_HASHIDS_SALT='secret-salt' \
   stack build \
     --fast \
     --no-run-tests \

--- a/scripts/run-api.sh
+++ b/scripts/run-api.sh
@@ -8,15 +8,15 @@ if [[ -f ./zoomhub-api.pid ]] ; then
   set -e
 fi
 
-ZH_ENV='development' \
-BASE_URI="${BASE_URI:-http://localhost:8000}" \
-CONTENT_BASE_URI='https://cache-development.zoomhub.net/content' \
 PGDATABASE='zoomhub_development' \
 PGUSER="$(whoami)" \
-PROCESS_CONTENT='ProcessExistingAndNewContent' \
-PROCESSING_WORKERS='2' \
-S3_SOURCES_BUCKET='zoomhub-sources-development' \
-UPLOADS='true' \
+ZH_BASE_URI="${ZH_BASE_URI:-http://localhost:8000}" \
+ZH_CONTENT_BASE_URI='https://cache-development.zoomhub.net/content' \
+ZH_ENV='development' \
+ZH_PROCESS_CONTENT='ProcessExistingAndNewContent' \
+ZH_PROCESSING_WORKERS='2' \
+ZH_S3_SOURCES_BUCKET='zoomhub-sources-development' \
+ZH_UPLOADS='true' \
   stack exec zoomhub | jq &
 
 echo $! > zoomhub-api.pid

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -11,13 +11,13 @@ if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
   exit 1
 fi
 
-if [[ -z "$API_USERNAME" ]]; then
-  echo "Please set 'API_USERNAME' environment variable"
+if [[ -z "$ZH_API_USERNAME" ]]; then
+  echo "Please set 'ZH_API_USERNAME' environment variable"
   exit 1
 fi
 
-if [[ -z "$API_PASSWORD" ]]; then
-  echo "Please set 'API_PASSWORD' environment variable"
+if [[ -z "$ZH_API_PASSWORD" ]]; then
+  echo "Please set 'ZH_API_PASSWORD' environment variable"
   exit 1
 fi
 
@@ -51,8 +51,8 @@ done
 echo ''
 
 
-BASE_URI=$NGROK_PUBLIC_URL \
-PUBLIC_PATH='frontend/public' \
+ZH_BASE_URI=$NGROK_PUBLIC_URL \
+ZH_PUBLIC_PATH='frontend/public' \
   npx concurrently \
     --names "api,web" \
     "./scripts/run-api-watch.sh" \

--- a/src/ZoomHub/Config/AWS.hs
+++ b/src/ZoomHub/Config/AWS.hs
@@ -27,5 +27,5 @@ fromEnv region = do
     Config
       <$> (T.pack <$> lookup "AWS_ACCESS_KEY_ID" env)
       <*> (T.pack <$> lookup "AWS_SECRET_ACCESS_KEY" env)
-      <*> (T.pack <$> lookup "S3_SOURCES_BUCKET" env)
+      <*> (T.pack <$> lookup "ZH_S3_SOURCES_BUCKET" env)
       <*> Just region

--- a/src/ZoomHub/Worker.hs
+++ b/src/ZoomHub/Worker.hs
@@ -76,7 +76,7 @@ processExistingContent Config {..} workerId = forever $ do
                   "apiURL" .= apiURL content
                 ]
     sleepBase = processExistingContentInterval
-    -- TODO: Split `BASE_URI` into `WWW_BASE_URI` and `API_BASE_URI`:
+    -- TODO: Split `ZH_BASE_URI` into `ZH_WWW_BASE_URI` and `ZH_API_BASE_URI`:
     wwwURL c = mconcat [show baseURI, "/", unContentId (contentId c)]
     apiURL c = mconcat [show baseURI, "/v1/content/", unContentId (contentId c)]
     extraLogMeta =

--- a/zh
+++ b/zh
@@ -63,7 +63,7 @@ test)
     dropdb --if-exists "$TEST_DB_NAME"
     createdb "$TEST_DB_NAME"
 
-    PGUSER="$(whoami)" HASHIDS_SALT='secret-salt' \
+    PGUSER="$(whoami)" ZH_HASHIDS_SALT='secret-salt' \
       stack build \
         --fast \
         --test \


### PR DESCRIPTION
- Namespace ZoomHub specific environment variables using `ZH_` prefix. We’ve had
  crashes on Elastic Beanstalk because `PUBLIC_PATH` environment variable was
  unset during new deployments. This change works around the suspicion that it’s
  a reserved environment variable name even though it couldn’t independently be
  verified.

  Affected environment variable names:

  - `ZH_API_PASSWORD`
  - `ZH_API_USERNAME`
  - `ZH_BASE_URI`
  - `ZH_CONTENT_BASE_URI`
  - `ZH_HASHIDS_SALT`
  - `ZH_LOG_LEVEL`
  - `ZH_PROCESS_CONTENT`
  - `ZH_PROCESSING_WORKERS`
  - `ZH_PUBLIC_PATH`
  - `ZH_S3_SOURCES_BUCKET`
  - `ZH_STATIC_BASE_URI`
  - `ZH_UPLOADS`