### PR TITLE
SEO: Set canonical URLs

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>ZoomHub · Share and view full-resolution images easily</title>
     <meta charset="utf-8" />
+    <title>ZoomHub · Share and view full-resolution images easily</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="canonical" href="https://zoomhub.net" />
+
     <meta name="theme-color" content="#171717" />
 
     <link rel="shortcut icon" href="favicon.ico" />

--- a/src/ZoomHub/Web/Page.hs
+++ b/src/ZoomHub/Web/Page.hs
@@ -4,6 +4,8 @@
 
 module ZoomHub.Web.Page
   ( layout,
+    Title(..),
+    Path(..),
     title,
     styles,
     analyticsScript,
@@ -30,22 +32,32 @@ import Lucid
     toHtml,
   )
 import NeatInterpolation (text)
+import Control.Monad (forM_)
 
 title :: Text
 title = "ZoomHub · Share and view full-resolution images easily"
 
+newtype Title = Title Text
+newtype Path = Path Text
+
 layout ::
   Monad m =>
-  Text -> -- title
+  Title ->
+  Maybe Path ->
   HtmlT m a ->
   HtmlT m a
-layout pageTitle body = do
+layout (Title pageTitle) mPath body = do
   doctypehtml_ $
     do
       head_
         ( do
-            title_ (toHtml pageTitle)
             meta_ [charset_ "utf-8"]
+            title_ (toHtml pageTitle)
+            forM_ mPath $ \(Path path) ->
+              link_
+                [ rel_ "canonical",
+                  href_ $ "https://zoomhub.net" <> path
+                ]
             meta_
               [ name_ "viewport",
                 content_ "width=device-width, initial-scale=1"
@@ -95,7 +107,7 @@ layout pageTitle body = do
             style_ styles
             script_ analyticsScript
         )
-      body_ $ body
+      body_ body
 
 -- TODO: Improve how we represent inline styles.
 styles :: Text

--- a/src/ZoomHub/Web/Page/VerifyContent.hs
+++ b/src/ZoomHub/Web/Page/VerifyContent.hs
@@ -20,6 +20,7 @@ import ZoomHub.API.Types.Content (Content, contentId, contentShareUrl)
 import ZoomHub.Types.BaseURI (BaseURI)
 import ZoomHub.Types.ContentId (ContentId, unContentId)
 import qualified ZoomHub.Web.Page as Page
+import ZoomHub.Web.Page (Title(Title))
 
 data VerifyContent = VerifyContent
   { vcResult :: VerificationResult,
@@ -57,8 +58,8 @@ progressScript cId =
     apiURL = "/v1/content/" <> T.pack (unContentId cId)
 
 instance ToHtml VerifyContent where
-  toHtml (VerifyContent {..}) =
-    Page.layout Page.title do
+  toHtml VerifyContent {..} =
+    Page.layout (Title Page.title) Nothing do
       H.div_
         [ H.style_ $
             T.intercalate

--- a/src/ZoomHub/Web/Page/ViewContent.hs
+++ b/src/ZoomHub/Web/Page/ViewContent.hs
@@ -27,6 +27,7 @@ import ZoomHub.API.Types.Content (Content, contentId, contentUrl)
 import ZoomHub.Types.BaseURI (BaseURI, unBaseURI)
 import ZoomHub.Types.ContentId (unContentId)
 import qualified ZoomHub.Web.Page as Page
+import ZoomHub.Web.Page (Path(..), Title (..))
 
 data ViewContent = ViewContent
   { vcContent :: Content,
@@ -39,7 +40,8 @@ mkViewContent vcBaseURI vcContent = ViewContent {..}
 
 instance ToHtml ViewContent where
   toHtml vc = Page.layout
-    (T.pack cId <> " — " <> Page.title)
+    (Title $ T.pack cId <> " — " <> Page.title)
+    (Just $ Path $ "/" <> T.pack cId)
     $ do
       script_ [src_ (T.pack $ show scriptURI)] emptyScriptBody
       div_ [class_ "meta"] $


### PR DESCRIPTION
Attempt to steer search engines from zoom.it to zoomhub.net.