### PR TITLE
2022-02-23-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # ZoomHub
 
+## 2022-02-23-2
+
+- Embed: Add `background` parameter
+
+  Customize embed background to be:
+
+  - `none` (transparent)
+  - `white`
+  - `black` (default)
+
+  Useful for branding as well as avoiding background bleed through on
+  `constrain=full` embeds.
+
+- Disable directory listings, e.g. on `/showcase/ecommerce/`.
+- Simplify `curl` example on homepage.
+
 ## 2022-02-23-1
 
 - View content page:

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -219,21 +219,7 @@
         </h2>
         <pre
           class="code-listing"
-        >&gt; curl --include --location 'https://api.zoomhub.net/v1/content?url=<span class="code-highlight">{url}</span>&email=<span class="code-highlight">{email}</span>'
-
-HTTP/1.1 301 Moved Permanently
-Server: nginx/1.20.0
-Date: Fri, 13 Aug 2021 16:20:00 GMT
-Transfer-Encoding: chunked
-Connection: keep-alive
-Location: https://api.zoomhub.net/v1/content/<span class="code-highlight">{id}</span>
-
-HTTP/1.1 200 OK
-Server: nginx/1.20.0
-Date: Fri, 13 Aug 2021 16:20:00 GMT
-Content-Type: application/json;charset=utf-8
-Transfer-Encoding: chunked
-Connection: keep-alive
+        >&gt; curl --location 'https://api.zoomhub.net/v1/content?url=<span class="code-highlight">{url}</span>&email=<span class="code-highlight">{email}</span>'
 
 {
   "id":"<span class="code-highlight">{id}</span>",

--- a/src/ZoomHub/API.hs
+++ b/src/ZoomHub/API.hs
@@ -126,6 +126,7 @@ import qualified ZoomHub.Types.VerificationError as VerificationError
 import ZoomHub.Types.VerificationToken (VerificationToken)
 import ZoomHub.Utils (lenientDecodeUtf8)
 import qualified ZoomHub.Web.Errors as Web
+import ZoomHub.Web.Page.EmbedContent (EmbedContent (..))
 import qualified ZoomHub.Web.Page.EmbedContent as Page
 import qualified ZoomHub.Web.Page.VerifyContent as Page
 import qualified ZoomHub.Web.Page.VerifyContent as VerificationResult
@@ -653,13 +654,14 @@ webEmbedIFrame
       Just c -> do
         let content = Content.fromInternal baseURI contentBaseURI c
         return $
-          Page.mkEmbedContent
-            baseURI
-            staticBaseURI
-            content
-            mObjectFit
-            mEmbedConstraint
-            mEmbedBackground
+          Page.EmbedContent
+            { ecBackgroundColor = mEmbedBackground,
+              ecBaseURI = baseURI,
+              ecConstraint = mEmbedConstraint,
+              ecContent = content,
+              ecObjectFit = mObjectFit,
+              ecStaticBaseURI = staticBaseURI
+            }
 
 -- Web: Embed
 webEmbed ::

--- a/src/ZoomHub/Web/Page/EmbedContent.hs
+++ b/src/ZoomHub/Web/Page/EmbedContent.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module ZoomHub.Web.Page.EmbedContent
-  ( EmbedContent,
-    mkEmbedContent,
+  ( EmbedContent (..),
   )
 where
 
@@ -34,31 +33,14 @@ import ZoomHub.Web.Types.OpenSeadragonTileSource (fromDeepZoomImage)
 import ZoomHub.Web.Types.OpenSeadragonViewerConfig (mkOpenSeadragonViewerConfig)
 
 data EmbedContent = EmbedContent
-  { ecContent :: Content,
-    ecBackgroundColor :: Maybe EmbedBackground,
+  { ecBackgroundColor :: Maybe EmbedBackground,
+    ecContent :: Content,
     ecBaseURI :: BaseURI,
     ecConstraint :: Maybe EmbedConstraint,
     ecObjectFit :: Maybe EmbedObjectFit,
     ecStaticBaseURI :: StaticBaseURI
   }
   deriving (Eq, Show)
-
-mkEmbedContent ::
-  BaseURI ->
-  StaticBaseURI ->
-  Content ->
-  Maybe EmbedObjectFit ->
-  Maybe EmbedConstraint ->
-  Maybe EmbedBackground ->
-  EmbedContent
-mkEmbedContent
-  ecBaseURI
-  ecStaticBaseURI
-  ecContent
-  ecObjectFit
-  ecConstraint
-  ecBackgroundColor =
-    EmbedContent {..}
 
 instance H.ToHtml EmbedContent where
   toHtml EmbedContent {..} =

--- a/src/ZoomHub/Web/Static.hs
+++ b/src/ZoomHub/Web/Static.hs
@@ -8,7 +8,7 @@ where
 import qualified Data.ByteString.Lazy as BL
 import Network.HTTP.Types (status404)
 import Network.Wai (Application, responseLBS)
-import Network.Wai.Application.Static (defaultFileServerSettings, ss404Handler)
+import Network.Wai.Application.Static (defaultFileServerSettings, ss404Handler, ssListing)
 import Servant.API.Raw (Raw)
 import Servant.Server (Server)
 import Servant.Server.StaticFiles (serveDirectoryWith)
@@ -18,7 +18,8 @@ serveDirectory :: BL.ByteString -> FilePath -> Server Raw
 serveDirectory error404 root =
   serveDirectoryWith
     (defaultFileServerSettings normalizedRoot)
-      { ss404Handler = Just (custom404Handler error404)
+      { ss404Handler = Just (custom404Handler error404),
+        ssListing = Nothing
       }
   where
     normalizedRoot = addTrailingPathSeparator root

--- a/src/ZoomHub/Web/Types/Embed.hs
+++ b/src/ZoomHub/Web/Types/Embed.hs
@@ -30,6 +30,8 @@ import ZoomHub.Types.DeepZoomImage
   )
 import ZoomHub.Types.StaticBaseURI (StaticBaseURI, unStaticBaseURI)
 import qualified ZoomHub.Web.Types.EmbedAspectRatio as EmbedAspectRatio
+import ZoomHub.Web.Types.EmbedBackground (EmbedBackground)
+import qualified ZoomHub.Web.Types.EmbedBackground as EmbedBackground
 import ZoomHub.Web.Types.EmbedBorder
 import qualified ZoomHub.Web.Types.EmbedBorder as EmbedBorder
 import ZoomHub.Web.Types.EmbedConstraint (EmbedConstraint (unEmbedConstraint))
@@ -49,7 +51,8 @@ data Embed = Embed
     embedWidth :: Maybe EmbedDimension,
     embedBorder :: Maybe EmbedBorder,
     embedObjectFit :: Maybe EmbedObjectFit,
-    embedConstraint :: Maybe EmbedConstraint
+    embedConstraint :: Maybe EmbedConstraint,
+    embedBackgroundColor :: Maybe EmbedBackground
   }
   deriving (Eq, Generic, Show)
 
@@ -67,18 +70,21 @@ defaultWidth :: EmbedDimension
 defaultWidth = Auto
 
 style :: Embed -> String
-style Embed {embedContent, embedWidth, embedHeight, embedBorder} =
-  unwords
-    [ "aspect-ratio: " <> EmbedAspectRatio.toCSSValue aspectRatio <> ";",
-      "background: black;",
-      "border: " <> EmbedBorder.toCSSValue border <> ";",
-      "color: white;",
-      "height: " <> EmbedDimension.toCSSValue height <> ";",
-      "margin: 0;",
-      "padding: 0;",
-      "width: " <> EmbedDimension.toCSSValue width <> ";"
-    ]
+style Embed {embedContent, embedWidth, embedHeight, embedBorder, embedBackgroundColor} =
+  T.unpack $
+    T.intercalate
+      ";"
+      [ "aspect-ratio: " <> EmbedAspectRatio.toCSSValue aspectRatio,
+        "background: " <> EmbedBackground.toCSSValue background,
+        "border: " <> EmbedBorder.toCSSValue border,
+        "color: white",
+        "height: " <> EmbedDimension.toCSSValue height,
+        "margin: 0",
+        "padding: 0",
+        "width: " <> EmbedDimension.toCSSValue width
+      ]
   where
+    background = fromMaybe EmbedBackground.Black embedBackgroundColor
     border = fromMaybe EmbedBorder.Default embedBorder
     height = fromMaybe defaultHeight embedHeight
     width = fromMaybe defaultWidth embedWidth

--- a/src/ZoomHub/Web/Types/EmbedAspectRatio.hs
+++ b/src/ZoomHub/Web/Types/EmbedAspectRatio.hs
@@ -1,14 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module ZoomHub.Web.Types.EmbedAspectRatio
   ( EmbedAspectRatio (..),
     toCSSValue,
   )
 where
 
+import Data.Text (Text)
+import qualified Data.Text as T
+
 data EmbedAspectRatio
   = Auto
   | Ratio Integer Integer
   deriving (Eq, Show)
 
-toCSSValue :: EmbedAspectRatio -> String
+toCSSValue :: EmbedAspectRatio -> Text
 toCSSValue Auto = "auto"
-toCSSValue (Ratio width height) = show width <> " / " <> show height
+toCSSValue (Ratio width height) = T.pack $ show width <> " / " <> show height

--- a/src/ZoomHub/Web/Types/EmbedBackground.hs
+++ b/src/ZoomHub/Web/Types/EmbedBackground.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ZoomHub.Web.Types.EmbedBackground
+  ( EmbedBackground (..),
+    toCSSValue,
+  )
+where
+
+import Data.Text (Text)
+import Servant (FromHttpApiData, parseUrlPiece)
+
+data EmbedBackground
+  = None
+  | Black
+  | White
+  deriving (Eq, Show)
+
+parse :: Text -> Either Text EmbedBackground
+parse value =
+  case value of
+    "none" -> Right None
+    "black" -> Right Black
+    "white" -> Right White
+    s -> Left $ "Invalid value: " <> s
+
+toCSSValue :: EmbedBackground -> Text
+toCSSValue value =
+  case value of
+    None -> "none"
+    Black -> "#000"
+    White -> "#fff"
+
+instance FromHttpApiData EmbedBackground where
+  parseUrlPiece = parse

--- a/src/ZoomHub/Web/Types/EmbedBorder.hs
+++ b/src/ZoomHub/Web/Types/EmbedBorder.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module ZoomHub.Web.Types.EmbedBorder
   ( EmbedBorder (..),
     toCSSValue,
@@ -5,8 +7,7 @@ module ZoomHub.Web.Types.EmbedBorder
   )
 where
 
-import Data.Bifunctor (first)
-import qualified Data.Text as T
+import Data.Text (Text)
 import Servant (FromHttpApiData, parseUrlPiece)
 
 -- Type
@@ -15,15 +16,15 @@ data EmbedBorder
   | Default
   deriving (Eq, Show)
 
-toCSSValue :: EmbedBorder -> String
+toCSSValue :: EmbedBorder -> Text
 toCSSValue None = "none"
 toCSSValue Default = "1px solid black"
 
 -- NOTE: We don’t allow the default border to be passed in as query param:
-parseCSSValue :: String -> Either String EmbedBorder
+parseCSSValue :: Text -> Either Text EmbedBorder
 parseCSSValue "none" = Right None
 parseCSSValue value = Left $ "Invalid value: " <> value
 
 -- Text
 instance FromHttpApiData EmbedBorder where
-  parseUrlPiece p = first T.pack $ parseCSSValue . T.unpack $ p
+  parseUrlPiece = parseCSSValue

--- a/zoomhub.cabal
+++ b/zoomhub.cabal
@@ -87,11 +87,12 @@ library
     , ZoomHub.Web.Static
     , ZoomHub.Web.Types.Embed
     , ZoomHub.Web.Types.EmbedAspectRatio
-    , ZoomHub.Web.Types.EmbedConstraint
+    , ZoomHub.Web.Types.EmbedBackground
     , ZoomHub.Web.Types.EmbedBorder
+    , ZoomHub.Web.Types.EmbedConstraint
     , ZoomHub.Web.Types.EmbedDimension
-    , ZoomHub.Web.Types.EmbedObjectFit
     , ZoomHub.Web.Types.EmbedId
+    , ZoomHub.Web.Types.EmbedObjectFit
     , ZoomHub.Web.Types.OpenSeadragonTileSource
     , ZoomHub.Web.Types.OpenSeadragonViewerConfig
     , ZoomHub.Worker


### PR DESCRIPTION
- Embed: Add `background` parameter

  Customize embed background to be:

  - `none` (transparent)
  - `white`
  - `black` (default)

  Useful for branding as well as avoiding background bleed through on
  `constrain=full` embeds.

- Disable directory listings, e.g. on `/showcase/ecommerce/`.
- Simplify `curl` example on homepage.
