### PR TITLE
Upgrade Universal Analytics to Google Analytics 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ZoomHub
 
+## 2024-03-28-1
+
+- Web: Upgrade Universal Analytics to Google Analytics 4, including script
+  embeds.
+
 ## 2024-03-27-3
 
 - `processContent`

--- a/frontend/public/404.html
+++ b/frontend/public/404.html
@@ -7,33 +7,22 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <!-- Google Analytics -->
-    <script>
-      ;(function (i, s, o, g, r, a, m) {
-        i["GoogleAnalyticsObject"] = r
-        ;(i[r] =
-          i[r] ||
-          function () {
-            ;(i[r].q = i[r].q || []).push(arguments)
-          }),
-          (i[r].l = 1 * new Date())
-        ;(a = s.createElement(o)), (m = s.getElementsByTagName(o)[0])
-        a.async = 1
-        a.src = g
-        m.parentNode.insertBefore(a, m)
-      })(
-        window,
-        document,
-        "script",
-        "//www.google-analytics.com/analytics.js",
-        "ga"
-      )
 
-      ga("create", "UA-55808703-1", "auto")
-      ga("_setDomainName", "zoomhub.net")
-      ga("_setAllowLinker", true)
-      ga("send", "pageview")
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-XLBYM4SR3W"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
+
+      gtag("config", "G-XLBYM4SR3W")
     </script>
+
     <style>
       body {
         background-color: #111;

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -46,33 +46,21 @@
       href="/apple-touch-icon-180x180.png"
     />
 
-    <!-- Google Analytics -->
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-XLBYM4SR3W"
+    ></script>
     <script>
-      ;(function (i, s, o, g, r, a, m) {
-        i["GoogleAnalyticsObject"] = r
-        ;(i[r] =
-          i[r] ||
-          function () {
-            ;(i[r].q = i[r].q || []).push(arguments)
-          }),
-          (i[r].l = 1 * new Date())
-        ;(a = s.createElement(o)), (m = s.getElementsByTagName(o)[0])
-        a.async = 1
-        a.src = g
-        m.parentNode.insertBefore(a, m)
-      })(
-        window,
-        document,
-        "script",
-        "//www.google-analytics.com/analytics.js",
-        "ga"
-      )
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-      ga("create", "UA-55808703-1", "auto")
-      ga("_setDomainName", "zoomhub.net")
-      ga("_setAllowLinker", true)
-      ga("send", "pageview")
+      gtag("config", "G-XLBYM4SR3W")
     </script>
+
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
     <link rel="stylesheet" type="text/css" href="/styles/global.css" />
     <style>

--- a/frontend/public/showcase/ecommerce/watches/index.html
+++ b/frontend/public/showcase/ecommerce/watches/index.html
@@ -37,32 +37,19 @@
       href="https://zoomhub-showcase.s3.amazonaws.com/scripts/seadragon/viewer.css"
     />
 
-    <!-- Google Analytics -->
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-XLBYM4SR3W"
+    ></script>
     <script>
-      ;(function (i, s, o, g, r, a, m) {
-        i["GoogleAnalyticsObject"] = r
-        ;(i[r] =
-          i[r] ||
-          function () {
-            ;(i[r].q = i[r].q || []).push(arguments)
-          }),
-          (i[r].l = 1 * new Date())
-        ;(a = s.createElement(o)), (m = s.getElementsByTagName(o)[0])
-        a.async = 1
-        a.src = g
-        m.parentNode.insertBefore(a, m)
-      })(
-        window,
-        document,
-        "script",
-        "//www.google-analytics.com/analytics.js",
-        "ga"
-      )
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag("js", new Date())
 
-      ga("create", "UA-55808703-1", "auto")
-      ga("_setDomainName", "zoomhub.net")
-      ga("_setAllowLinker", true)
-      ga("send", "pageview")
+      gtag("config", "G-XLBYM4SR3W")
     </script>
   </head>
   <body>

--- a/src/ZoomHub/Config.hs
+++ b/src/ZoomHub/Config.hs
@@ -3,13 +3,15 @@
 
 module ZoomHub.Config
   ( Config (..),
-    defaultPort,
     APIUser,
+    defaultPort,
+    googleAnalyticsMeasurementId,
   )
 where
 
 import Data.Aeson (ToJSON, object, toJSON, (.=))
 import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
 import Data.Time.Units (Second)
 import Data.Time.Units.Instances ()
 import qualified Database.PostgreSQL.Simple as PGS
@@ -30,6 +32,9 @@ import ZoomHub.Types.StaticBaseURI (StaticBaseURI)
 
 defaultPort :: Integer
 defaultPort = 8000
+
+googleAnalyticsMeasurementId :: Text
+googleAnalyticsMeasurementId = "G-XLBYM4SR3W"
 
 data Config = Config
   { apiUser :: APIUser,

--- a/src/ZoomHub/Web/Page.hs
+++ b/src/ZoomHub/Web/Page.hs
@@ -55,24 +55,28 @@ layout Page {..} = do
       H.link_ [H.rel_ "stylesheet", H.type_ "text/css", H.href_ "https://rsms.me/inter/inter.css"]
       H.link_ [H.rel_ "stylesheet", H.type_ "text/css", H.href_ "/styles/global.css"]
 
-      H.script_ analyticsScript
+      analyticsScript
     H.body_ [H.class_ "h-full bg-black m-0 p-0"] pageBody
 
--- TODO: Improve how we represent analytics code.
--- TODO: Pass through `UA-XXXXXXXX-X` Google Analytics ID.
-analyticsScript :: Text
-analyticsScript =
-  [text|
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+--- TODO: Improve how we represent analytics code.
+--- TODO: Pass through `G-*` Google Analytics measurement ID.
+analyticsScript :: (Monad m) => H.HtmlT m ()
+analyticsScript = do
+  H.script_
+    [ H.async_ "async",
+      H.src_ ("https://www.googletagmanager.com/gtag/js?id=" <> measurementId)
+    ]
+    ("" :: Text)
+  H.script_
+    [text|
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    ga('create', 'UA-55808703-1', 'auto');
-    ga('_setDomainName', 'zoomhub.net');
-    ga('_setAllowLinker', true);
-    ga('send', 'pageview');
-  |]
+      gtag('config', "$measurementId");
+    |]
+  where
+    measurementId = "G-XLBYM4SR3W" :: Text
 
 appleTouchIcons :: (Monad m) => H.HtmlT m ()
 appleTouchIcons = do

--- a/src/ZoomHub/Web/Page.hs
+++ b/src/ZoomHub/Web/Page.hs
@@ -17,6 +17,7 @@ import Control.Monad (forM_)
 import Data.Text (Text)
 import qualified Lucid as H
 import NeatInterpolation (text)
+import qualified ZoomHub.Config as Config
 
 title :: Text
 title = "ZoomHub · Share and view full-resolution images easily"
@@ -76,7 +77,7 @@ analyticsScript = do
       gtag('config', "$measurementId");
     |]
   where
-    measurementId = "G-XLBYM4SR3W" :: Text
+    measurementId = Config.googleAnalyticsMeasurementId
 
 appleTouchIcons :: (Monad m) => H.HtmlT m ()
 appleTouchIcons = do

--- a/src/ZoomHub/Web/Types/Embed.hs
+++ b/src/ZoomHub/Web/Types/Embed.hs
@@ -22,6 +22,7 @@ import ZoomHub.API.Types.Content (Content, contentDzi, contentReady)
 import qualified ZoomHub.API.Types.Content as API
 import ZoomHub.API.Types.DeepZoomImage (DeepZoomImageURI (..), mkDeepZoomImage)
 import qualified ZoomHub.API.Types.DeepZoomImage as API
+import qualified ZoomHub.Config as Config
 import ZoomHub.Types.BaseURI (BaseURI)
 import ZoomHub.Types.DeepZoomImage
   ( TileFormat (PNG),
@@ -132,8 +133,21 @@ instance ToJS Embed where
               viewer.canvas.style.backgroundColor =
                 fullPage ? "black" : "$backgroundColor"
             })
+
+            // Google Analytics 4
+            const script = document.createElement('script')
+            script.async = true
+            script.src = "https://www.googletagmanager.com/gtag/js?id=$measurementId"
+            document.head.appendChild(script)
+
+            window.dataLayer = window.dataLayer || []
+            window.gtag = window.gtag || function gtag() { dataLayer.push(arguments) }
+            gtag("js", new Date())
+
+            gtag("config", "$measurementId")
           })()
         |]
+      measurementId = Config.googleAnalyticsMeasurementId
       openSeadragonConfig = T.pack $ BLC.unpack $ encode viewerConfig
       backgroundColor =
         EmbedBackground.toCSSValue $


### PR DESCRIPTION
## 2024-03-28-1

- **Web:** Upgrade Universal Analytics to Google Analytics 4, including script embeds.